### PR TITLE
클라이밍장 조회, 추가 API 구현

### DIFF
--- a/src/main/java/com/first/flash/FlashApplication.java
+++ b/src/main/java/com/first/flash/FlashApplication.java
@@ -6,8 +6,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class FlashApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(FlashApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(FlashApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -19,10 +19,9 @@ public class ClimbingGymService {
     private final ClimbingGymRepository climbingGymRepository;
 
     @Transactional
-    public ClimbingGymResponseDto save(final ClimbingGymCreateRequestDto createRequestDto) {
+    public Long save(final ClimbingGymCreateRequestDto createRequestDto) {
         ClimbingGym newGym = createRequestDto.toEntity();
-        ClimbingGym savedGym = climbingGymRepository.save(newGym);
-        return ClimbingGymResponseDto.toDto(savedGym);
+        return climbingGymRepository.save(newGym);
     }
 
     public ClimbingGym findClimbingGymById(final Long id) {

--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -5,6 +5,8 @@ import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,5 +28,11 @@ public class ClimbingGymService {
     public ClimbingGym findClimbingGymById(final Long id) {
         return climbingGymRepository.findById(id)
             .orElseThrow(()-> new ClimbingGymNotFoundException(id));
+    }
+
+    public List<ClimbingGymResponseDto> findAllClimbingGyms() {
+        return climbingGymRepository.findAll().stream()
+            .map(ClimbingGymResponseDto::toDto)
+            .toList();
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -6,7 +6,6 @@ import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,7 +25,7 @@ public class ClimbingGymService {
 
     public ClimbingGym findClimbingGymById(final Long id) {
         return climbingGymRepository.findById(id)
-            .orElseThrow(()-> new ClimbingGymNotFoundException(id));
+            .orElseThrow(() -> new ClimbingGymNotFoundException(id));
     }
 
     public List<ClimbingGymResponseDto> findAllClimbingGyms() {

--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.gym.application;
 
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
@@ -18,9 +19,9 @@ public class ClimbingGymService {
     private final ClimbingGymRepository climbingGymRepository;
 
     @Transactional
-    public Long save(final ClimbingGymCreateRequestDto createRequestDto) {
+    public ClimbingGymCreateResponseDto save(final ClimbingGymCreateRequestDto createRequestDto) {
         ClimbingGym newGym = createRequestDto.toEntity();
-        return climbingGymRepository.save(newGym);
+        return ClimbingGymCreateResponseDto.toDto(climbingGymRepository.save(newGym));
     }
 
     public ClimbingGym findClimbingGymById(final Long id) {

--- a/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymCreateRequestDto.java
@@ -4,7 +4,8 @@ import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.vo.Difficulty;
 import java.util.List;
 
-public record ClimbingGymCreateRequestDto(String gymName, String thumbnailUrl, String mapImageUrl, List<Difficulty> difficulties) {
+public record ClimbingGymCreateRequestDto(String gymName, String thumbnailUrl, String mapImageUrl,
+                                          List<Difficulty> difficulties) {
 
     public ClimbingGym toEntity() {
         return new ClimbingGym(gymName, thumbnailUrl, mapImageUrl, difficulties);

--- a/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymCreateResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymCreateResponseDto.java
@@ -1,0 +1,14 @@
+package com.first.flash.climbing.gym.application.dto;
+
+import com.first.flash.climbing.gym.domian.ClimbingGym;
+import com.first.flash.climbing.gym.domian.vo.Difficulty;
+import java.util.List;
+
+public record ClimbingGymCreateResponseDto(Long id, String gymName, String thumbnailUrl,
+                                           String mapImageUrl, List<Difficulty> difficulties) {
+
+    public static ClimbingGymCreateResponseDto toDto(final ClimbingGym gym) {
+        return new ClimbingGymCreateResponseDto(gym.getId(), gym.getGymName(),
+            gym.getThumbnailUrl(), gym.getMapImageUrl(), gym.getDifficulties());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymResponseDto.java
@@ -1,14 +1,10 @@
 package com.first.flash.climbing.gym.application.dto;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
-import com.first.flash.climbing.gym.domian.vo.Difficulty;
-import java.util.List;
 
-public record ClimbingGymResponseDto(String gymName, String thumbnailUrl, String mapImageUrl,
-                                     List<Difficulty> difficulties) {
+public record ClimbingGymResponseDto(Long id, String gymName, String thumbnailUrl) {
 
     public static ClimbingGymResponseDto toDto(final ClimbingGym gym) {
-        return new ClimbingGymResponseDto(gym.getGymName(), gym.getThumbnailUrl(),
-            gym.getMapImageUrl(), gym.getDifficulties());
+        return new ClimbingGymResponseDto(gym.getId(), gym.getGymName(), gym.getThumbnailUrl());
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGym.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGym.java
@@ -12,11 +12,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OrderColumn;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class ClimbingGym {
 

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
@@ -5,7 +5,9 @@ import java.util.Optional;
 
 public interface ClimbingGymRepository {
 
-    ClimbingGym save(final ClimbingGym gym);
+    Long save(final ClimbingGym gym);
+
     Optional<ClimbingGym> findById(final Long id);
+
     List<ClimbingGym> findAll();
 }

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 public interface ClimbingGymRepository {
 
-    Long save(final ClimbingGym gym);
+    ClimbingGym save(final ClimbingGym gym);
 
     Optional<ClimbingGym> findById(final Long id);
 

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
@@ -1,9 +1,11 @@
 package com.first.flash.climbing.gym.domian;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ClimbingGymRepository {
 
     ClimbingGym save(final ClimbingGym gym);
     Optional<ClimbingGym> findById(final Long id);
+    List<ClimbingGym> findAll();
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymJpaRepository.java
@@ -1,11 +1,15 @@
 package com.first.flash.climbing.gym.infrastructure;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClimbingGymJpaRepository extends JpaRepository<ClimbingGym, Long> {
 
     ClimbingGym save(final ClimbingGym gym);
+
     Optional<ClimbingGym> findById(final Long id);
+
+    List<ClimbingGym> findAll();
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
@@ -14,8 +14,8 @@ public class ClimbingGymRepositoryImpl implements ClimbingGymRepository {
     private final ClimbingGymJpaRepository climbingGymJpaRepository;
 
     @Override
-    public Long save(final ClimbingGym gym) {
-        return climbingGymJpaRepository.save(gym).getId();
+    public ClimbingGym save(final ClimbingGym gym) {
+        return climbingGymJpaRepository.save(gym);
     }
 
     @Override

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
@@ -14,8 +14,8 @@ public class ClimbingGymRepositoryImpl implements ClimbingGymRepository {
     private final ClimbingGymJpaRepository climbingGymJpaRepository;
 
     @Override
-    public ClimbingGym save(final ClimbingGym gym) {
-        return climbingGymJpaRepository.save(gym);
+    public Long save(final ClimbingGym gym) {
+        return climbingGymJpaRepository.save(gym).getId();
     }
 
     @Override

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.gym.infrastructure;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,5 +21,10 @@ public class ClimbingGymRepositoryImpl implements ClimbingGymRepository {
     @Override
     public Optional<ClimbingGym> findById(final Long id) {
         return climbingGymJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<ClimbingGym> findAll() {
+        return climbingGymJpaRepository.findAll();
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -37,7 +37,7 @@ public class ClimbingGymController {
     }
 
     @GetMapping("/{gymId}")
-    public ClimbingGym getGymDetails(@PathVariable Long gymId) {
+    public ClimbingGym getGymDetails(@PathVariable final Long gymId) {
         return climbingGymService.findClimbingGymById(gymId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -1,0 +1,43 @@
+package com.first.flash.climbing.gym.ui;
+
+import com.first.flash.climbing.gym.application.ClimbingGymService;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
+import com.first.flash.climbing.gym.domian.ClimbingGym;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/gyms")
+@RequiredArgsConstructor
+public class ClimbingGymController {
+
+    private final ClimbingGymService climbingGymService;
+
+    @GetMapping
+    public List<ClimbingGymResponseDto> getGyms() {
+        return climbingGymService.findAllClimbingGyms().stream()
+            .toList();
+    }
+
+    @PostMapping
+    public ResponseEntity<ClimbingGymCreateResponseDto> createGym(
+        @RequestBody final ClimbingGymCreateRequestDto gymCreateRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(climbingGymService.save(gymCreateRequestDto));
+    }
+
+    @GetMapping("/{gymId}")
+    public ClimbingGym getGymDetails(@PathVariable Long gymId) {
+        return climbingGymService.findClimbingGymById(gymId);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/gym/ui/save
+++ b/src/main/java/com/first/flash/climbing/gym/ui/save
@@ -1,1 +1,0 @@
-save controller

--- a/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
@@ -6,17 +6,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class ClimbingGymServiceTest {
-
-    private final Long FIRST_GYM_ID = 1L;
 
     @Autowired
     ClimbingGymService climbingGymService;
@@ -28,8 +28,8 @@ class ClimbingGymServiceTest {
         ClimbingGymCreateRequestDto createDto = createDefaultGymCreateRequestDto();
 
         // when
-        climbingGymService.save(createDto);
-        ClimbingGym foundGym = climbingGymService.findClimbingGymById(FIRST_GYM_ID);
+        Long savedId = climbingGymService.save(createDto);
+        ClimbingGym foundGym = climbingGymService.findClimbingGymById(savedId);
 
         // then
         assertSoftly(softly -> {
@@ -45,8 +45,8 @@ class ClimbingGymServiceTest {
         ClimbingGymCreateRequestDto createDto = createDefaultGymCreateRequestDto();
 
         // when
-        climbingGymService.save(createDto);
-        ClimbingGym foundGym = climbingGymService.findClimbingGymById(FIRST_GYM_ID);
+        Long savedId = climbingGymService.save(createDto);
+        ClimbingGym foundGym = climbingGymService.findClimbingGymById(savedId);
 
         // then
         assertThat(foundGym).isNotNull();
@@ -58,5 +58,22 @@ class ClimbingGymServiceTest {
         // when & then
         assertThatThrownBy(() -> climbingGymService.findClimbingGymById(100L))
             .isInstanceOf(ClimbingGymNotFoundException.class);
+    }
+
+    @Test
+    @Transactional
+    void 클라이밍장_다건_검색() {
+        // given
+        ClimbingGymCreateRequestDto createDto1 = createDefaultGymCreateRequestDto();
+        ClimbingGymCreateRequestDto createDto2 = createDefaultGymCreateRequestDto();
+        climbingGymService.save(createDto1);
+        climbingGymService.save(createDto2);
+
+        // when
+        List<ClimbingGymResponseDto> gyms = climbingGymService.findAllClimbingGyms();
+
+        // then
+        assertThat(gyms).isNotEmpty();
+        assertThat(gyms.size()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
@@ -74,7 +74,9 @@ class ClimbingGymServiceTest {
         List<ClimbingGymResponseDto> gyms = climbingGymService.findAllClimbingGyms();
 
         // then
-        assertThat(gyms).isNotEmpty();
-        assertThat(gyms.size()).isEqualTo(2);
+        assertSoftly(softly -> {
+            softly.assertThat(gyms).isNotEmpty();
+            softly.assertThat(gyms.size()).isEqualTo(2);
+        });
     }
 }

--- a/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
@@ -28,8 +29,8 @@ class ClimbingGymServiceTest {
         ClimbingGymCreateRequestDto createDto = createDefaultGymCreateRequestDto();
 
         // when
-        Long savedId = climbingGymService.save(createDto);
-        ClimbingGym foundGym = climbingGymService.findClimbingGymById(savedId);
+        ClimbingGymCreateResponseDto saveDto = climbingGymService.save(createDto);
+        ClimbingGym foundGym = climbingGymService.findClimbingGymById(saveDto.id());
 
         // then
         assertSoftly(softly -> {
@@ -45,8 +46,8 @@ class ClimbingGymServiceTest {
         ClimbingGymCreateRequestDto createDto = createDefaultGymCreateRequestDto();
 
         // when
-        Long savedId = climbingGymService.save(createDto);
-        ClimbingGym foundGym = climbingGymService.findClimbingGymById(savedId);
+        ClimbingGymCreateResponseDto saveDto = climbingGymService.save(createDto);
+        ClimbingGym foundGym = climbingGymService.findClimbingGymById(saveDto.id());
 
         // then
         assertThat(foundGym).isNotNull();

--- a/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
@@ -9,21 +9,25 @@ import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
+import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
-import jakarta.transaction.Transactional;
+import com.first.flash.climbing.gym.infrastructure.FakeClimbingGymRepository;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class ClimbingGymServiceTest {
 
-    @Autowired
+    ClimbingGymRepository climbingGymRepository;
     ClimbingGymService climbingGymService;
 
+    @BeforeEach
+    void init() {
+        climbingGymRepository = new FakeClimbingGymRepository();
+        climbingGymService = new ClimbingGymService(climbingGymRepository);
+    }
+
     @Test
-    @Transactional
     void 클라이밍장_저장() {
         // given
         ClimbingGymCreateRequestDto createDto = createDefaultGymCreateRequestDto();
@@ -40,7 +44,6 @@ class ClimbingGymServiceTest {
     }
 
     @Test
-    @Transactional
     void 클라이밍장_단건_검색() {
         // given
         ClimbingGymCreateRequestDto createDto = createDefaultGymCreateRequestDto();
@@ -54,7 +57,6 @@ class ClimbingGymServiceTest {
     }
 
     @Test
-    @Transactional
     void 클라이밍장_단건_검색_예외() {
         // when & then
         assertThatThrownBy(() -> climbingGymService.findClimbingGymById(100L))
@@ -62,7 +64,6 @@ class ClimbingGymServiceTest {
     }
 
     @Test
-    @Transactional
     void 클라이밍장_다건_검색() {
         // given
         ClimbingGymCreateRequestDto createDto1 = createDefaultGymCreateRequestDto();

--- a/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/gym/application/ClimbingGymServiceTest.java
@@ -18,8 +18,8 @@ import org.junit.jupiter.api.Test;
 
 class ClimbingGymServiceTest {
 
-    ClimbingGymRepository climbingGymRepository;
-    ClimbingGymService climbingGymService;
+    private ClimbingGymRepository climbingGymRepository;
+    private ClimbingGymService climbingGymService;
 
     @BeforeEach
     void init() {

--- a/src/test/java/com/first/flash/climbing/gym/domian/ClimbingGymTest.java
+++ b/src/test/java/com/first/flash/climbing/gym/domian/ClimbingGymTest.java
@@ -12,16 +12,16 @@ class ClimbingGymTest {
     private final static String DEFAULT_CLIMBING_DIFFICULTY = "빨강";
 
     @Test
-    void validateDifficultyName() {
+    void 난이도_이름_검증() {
         // given
         ClimbingGym gym = createDefaultGym();
 
         // when & them
-        assertDoesNotThrow(()->gym.getDifficultyByName(DEFAULT_CLIMBING_DIFFICULTY));
+        assertDoesNotThrow(() -> gym.getDifficultyByName(DEFAULT_CLIMBING_DIFFICULTY));
     }
 
     @Test
-    void validateDifficultyException() {
+    void 난이도_이름_검증_예외() {
         // given
         ClimbingGym gym = createDefaultGym();
 

--- a/src/test/java/com/first/flash/climbing/gym/infrastructure/FakeClimbingGymRepository.java
+++ b/src/test/java/com/first/flash/climbing/gym/infrastructure/FakeClimbingGymRepository.java
@@ -1,0 +1,34 @@
+package com.first.flash.climbing.gym.infrastructure;
+
+import com.first.flash.climbing.gym.domian.ClimbingGym;
+import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeClimbingGymRepository implements ClimbingGymRepository {
+
+    final private Map<Long, ClimbingGym> db = new HashMap<>();
+    private Long id = 0L;
+
+    @Override
+    public ClimbingGym save(final ClimbingGym gym) {
+        ClimbingGym savedGym = new ClimbingGym(id++, gym.getGymName(), gym.getThumbnailUrl(),
+            gym.getMapImageUrl(), gym.getDifficulties());
+
+        db.put(savedGym.getId(), savedGym);
+        return savedGym;
+    }
+
+    @Override
+    public Optional<ClimbingGym> findById(final Long id) {
+        return Optional.ofNullable(db.get(id));
+    }
+
+    @Override
+    public List<ClimbingGym> findAll() {
+        return new ArrayList<>(db.values());
+    }
+}


### PR DESCRIPTION
클라이밍장 단건, 다건 조회 및 추가 API를 구현하였습니다.

## 클라이밍장 리스트 조회 (다건 조회)

### 예시
- request: `GET /gym`
- response: 200 OK
```json
[
    {
        "id": 1,
        "gymName": "hanyuClimbingGym",
        "thumbnailUrl": "example.png"
    },
    {
        "id": 2,
        "gymName": "hanyuClimbingGym 논현점",
        "thumbnailUrl": "AwesomeThumbnail.png"
    },
    {
        "id": 3,
        "gymName": "hanyuClimbingGym 강남점",
        "thumbnailUrl": "AwesomeThumbnail2.png"
    }
]
```

## 클라이밍장 정보 조회 (단건 조회)

- API 설계에는 클라이밍장에 포함되어 있는 Sector 정보를 전달
```
{
    "mapImageUrl": string,
    "difficulties": string[],
    "sectors": string[]
}
```
- querydsl 적용 예정이기 때문에 우선 아래와 같이 구현한 상태로 병합하기로 결정
  - 추후 querydsl 적용 시 함께 수정 예정

### 예시
- request: `GET /gym/{gymId}`
- response: 200 OK
```json
{
    "id": 3,
    "gymName": "hanyuClimbingGym 강남점",
    "thumbnailUrl": "AwesomeThumbnail2.png",
    "mapImageUrl": "map2.png",
    "difficulties": [
        {
            "name": "파랑",
            "level": 1
        },
        {
            "name": "빨강",
            "level": 2
        },
        {
            "name": "보라",
            "level": 3
        }
    ]
}
```

## 클라이밍장 생성

- 기존 설계한 API 명세에는 이미지 Url을 받도록 되어 있음
  - 현재 브랜치에서는 기존 명세대로 구현되어 있음
- 이미지 업로드를 서버에서 처리하기로 결정됨
  - 클라이언트에서 이미지를 다루는 것이 보안상 위험하다고 판단
- 추후에 이미지 업로드 파트를 분리할 예정이기 때문에 Url 인자가 수정될 예정
  - thumbnail, mapImage를 이미지 파일로 받아 업로드
- 응답 본문을 위해 `ClimbingGymCreateResponseDto`을 제작

### 예시
- request: `POST /gym`
```json
{
    "gymName": "hanyuClimbingGym 강남점",
    "thumbnailUrl": "AwesomeThumbnail2.png",
    "mapImageUrl": "map2.png",
    "difficulties": [
		{
            "name": "파랑",
            "level": 1
        },
        {
            "name": "빨강",
            "level": 2
        },
        {
            "name": "보라",
            "level": 3
        }
	]
}

```
- response: 201 CREATED
```json
{
    "id": 3,
    "gymName": "hanyuClimbingGym 강남점",
    "thumbnailUrl": "AwesomeThumbnail2.png",
    "mapImageUrl": "map2.png",
    "difficulties": [
        {
            "name": "파랑",
            "level": 1
        },
        {
            "name": "빨강",
            "level": 2
        },
        {
            "name": "보라",
            "level": 3
        }
    ]
}
```

## 기타 수정 사항

- 테스트명을 한글로 수정
- 코드 포맷이 google style로 되어있지 않던 부분 수정
- 패키지 유지를 위한 임시 파일 삭제
