### PR TITLE
문제 업로드 API 생성

### DIFF
--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsSaveService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsSaveService.java
@@ -1,0 +1,42 @@
+package com.first.flash.climbing.problem.application;
+
+import com.first.flash.climbing.gym.application.ClimbingGymService;
+import com.first.flash.climbing.gym.domian.ClimbingGym;
+import com.first.flash.climbing.problem.application.dto.ProblemCreateResponseDto;
+import com.first.flash.climbing.problem.domain.Problem;
+import com.first.flash.climbing.problem.domain.ProblemRepository;
+import com.first.flash.climbing.problem.domain.QueryProblem;
+import com.first.flash.climbing.problem.domain.ProblemsCreateService;
+import com.first.flash.climbing.problem.domain.QueryProblemRepository;
+import com.first.flash.climbing.problem.domain.dto.ProblemCreateRequestDto;
+import com.first.flash.climbing.sector.application.SectorService;
+import com.first.flash.climbing.sector.domain.Sector;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemsSaveService {
+
+    private final ProblemRepository problemRepository;
+    private final QueryProblemRepository queryProblemRepository;
+    private final ClimbingGymService climbingGymService;
+    private final SectorService sectorService;
+    private final ProblemsCreateService problemsCreateService;
+
+    @Transactional
+    public ProblemCreateResponseDto saveProblems(final Long gymId, final Long sectorId,
+        final ProblemCreateRequestDto createRequestDto) {
+        ClimbingGym climbingGym = climbingGymService.findClimbingGymById(gymId);
+        Sector sector = sectorService.findById(sectorId);
+        Problem problem = problemsCreateService.createProblem(climbingGym, sector,
+            createRequestDto);
+        QueryProblem queryProblem = problemsCreateService.createQueryProblem(climbingGym,
+            sector, problem);
+        problemRepository.save(problem);
+        queryProblemRepository.save(queryProblem);
+        return ProblemCreateResponseDto.toDto(problem);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
@@ -1,0 +1,26 @@
+package com.first.flash.climbing.problem.application.dto;
+
+import com.first.flash.climbing.problem.domain.Problem;
+import com.first.flash.climbing.problem.domain.vo.DifficultyInfo;
+import java.util.UUID;
+import lombok.Builder;
+
+@Builder
+public record ProblemCreateResponseDto(UUID id, String imageUrl, Integer views, Boolean isExpired,
+                                       DifficultyInfo difficultyInfo, Long optionalWeight,
+                                       Long gymId, Long sectorId
+) {
+
+    public static ProblemCreateResponseDto toDto(final Problem problem) {
+        return ProblemCreateResponseDto.builder()
+                                       .id(problem.getId())
+                                       .imageUrl(problem.getImageUrl())
+                                       .views(problem.getViews())
+                                       .isExpired(problem.getIsExpired())
+                                       .difficultyInfo(problem.getDifficultyInfo())
+                                       .optionalWeight(problem.getOptionalWeight())
+                                       .gymId(problem.getGymId())
+                                       .sectorId(problem.getSectorId())
+                                       .build();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
@@ -1,0 +1,55 @@
+package com.first.flash.climbing.problem.domain;
+
+import com.first.flash.climbing.problem.domain.vo.DifficultyInfo;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Problem {
+
+    private static final Long DEFAULT_OPTIONAL_WEIGHT = 0L;
+    private static final Integer DEFAULT_VIEWS = 0;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String imageUrl;
+    private Integer views;
+    private Boolean isExpired;
+    private DifficultyInfo difficultyInfo;
+    private Long optionalWeight;
+    private Long gymId;
+    private Long sectorId;
+
+    public Problem(final String imageUrl, final Integer views, final Boolean isExpired,
+        final DifficultyInfo difficultyInfo, final Long optionalWeight, final Long gymId,
+        final Long sectorId) {
+        this.imageUrl = imageUrl;
+        this.views = views;
+        this.isExpired = isExpired;
+        this.difficultyInfo = difficultyInfo;
+        this.optionalWeight = optionalWeight;
+        this.gymId = gymId;
+        this.sectorId = sectorId;
+    }
+
+    public static Problem createDefault(final String imageUrl, final Boolean isExpired,
+        final String difficultyName, final Integer difficultyLevel, final Long gymId,
+        final Long sectorId) {
+        return new Problem(imageUrl, DEFAULT_VIEWS, isExpired,
+            DifficultyInfo.of(difficultyName, difficultyLevel), DEFAULT_OPTIONAL_WEIGHT, gymId,
+            sectorId);
+    }
+
+    public void view() {
+        views++;
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
@@ -2,25 +2,27 @@ package com.first.flash.climbing.problem.domain;
 
 import com.first.flash.climbing.problem.domain.vo.DifficultyInfo;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @Getter
 public class Problem {
 
     private static final Long DEFAULT_OPTIONAL_WEIGHT = 0L;
     private static final Integer DEFAULT_VIEWS = 0;
+    private static final Boolean DEFAULT_IS_EXPIRED = false;
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private UUID id;
     private String imageUrl;
     private Integer views;
     private Boolean isExpired;
@@ -29,24 +31,19 @@ public class Problem {
     private Long gymId;
     private Long sectorId;
 
-    public Problem(final String imageUrl, final Integer views, final Boolean isExpired,
-        final DifficultyInfo difficultyInfo, final Long optionalWeight, final Long gymId,
-        final Long sectorId) {
-        this.imageUrl = imageUrl;
-        this.views = views;
-        this.isExpired = isExpired;
-        this.difficultyInfo = difficultyInfo;
-        this.optionalWeight = optionalWeight;
-        this.gymId = gymId;
-        this.sectorId = sectorId;
-    }
-
-    public static Problem createDefault(final String imageUrl, final Boolean isExpired,
+    public static Problem createDefault(final UUID id, final String imageUrl,
         final String difficultyName, final Integer difficultyLevel, final Long gymId,
         final Long sectorId) {
-        return new Problem(imageUrl, DEFAULT_VIEWS, isExpired,
-            DifficultyInfo.of(difficultyName, difficultyLevel), DEFAULT_OPTIONAL_WEIGHT, gymId,
-            sectorId);
+        return Problem.builder()
+                      .id(id)
+                      .imageUrl(imageUrl)
+                      .views(DEFAULT_VIEWS)
+                      .isExpired(DEFAULT_IS_EXPIRED)
+                      .difficultyInfo(DifficultyInfo.of(difficultyName, difficultyLevel))
+                      .optionalWeight(DEFAULT_OPTIONAL_WEIGHT)
+                      .gymId(gymId)
+                      .sectorId(sectorId)
+                      .build();
     }
 
     public void view() {

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.problem.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface ProblemRepository {
+
+    Problem save(final Problem problem);
+
+    Optional<Problem> findById(final UUID id);
+}

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
@@ -1,0 +1,41 @@
+package com.first.flash.climbing.problem.domain;
+
+import com.first.flash.climbing.gym.domian.ClimbingGym;
+import com.first.flash.climbing.gym.domian.vo.Difficulty;
+import com.first.flash.climbing.problem.domain.dto.ProblemCreateRequestDto;
+import com.first.flash.climbing.sector.domain.Sector;
+import java.util.UUID;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ProblemsCreateService {
+
+    private static final Boolean DEFAULT_HAS_SOLUTION = false;
+
+    public Problem createProblem(final ClimbingGym climbingGym, final Sector sector,
+        final ProblemCreateRequestDto createRequestDto) {
+        Difficulty difficulty = climbingGym.getDifficultyByName(createRequestDto.difficulty());
+        return Problem.createDefault(UUID.randomUUID(), createRequestDto.imageUrl(),
+            difficulty.getName(), difficulty.getLevel(), climbingGym.getId(), sector.getId());
+    }
+
+    public QueryProblem createQueryProblem(final ClimbingGym climbingGym, final Sector sector,
+        final Problem problem) {
+        return QueryProblem.builder()
+                           .id(problem.getId())
+                           .imageUrl(problem.getImageUrl())
+                           .views(problem.getViews())
+                           .isExpired(problem.getIsExpired())
+                           .hasSolution(DEFAULT_HAS_SOLUTION)
+                           .difficultyName(problem.getDifficultyInfo().getDifficultyName())
+                           .difficultyLevel(problem.getDifficultyInfo().getLevel())
+                           .optionalWeight(problem.getOptionalWeight())
+                           .gymId(problem.getGymId())
+                           .gymName(climbingGym.getGymName())
+                           .sectorId(problem.getSectorId())
+                           .sectorName(sector.getSectorName().getName())
+                           .settingDate(sector.getSettingDate())
+                           .removalDate(sector.getRemovalDate())
+                           .build();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -1,0 +1,37 @@
+package com.first.flash.climbing.problem.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.time.LocalDate;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class QueryProblem {
+
+    private static final Boolean DEFAULT_HAS_SOLUTION = false;
+
+    @Id
+    private UUID id;
+    private String imageUrl;
+    private Integer views;
+    private Boolean isExpired;
+    private Boolean hasSolution;
+    private String difficultyName;
+    private Integer difficultyLevel;
+    private Long optionalWeight;
+    private Long gymId;
+    private String gymName;
+    private Long sectorId;
+    private String sectorName;
+    private LocalDate settingDate;
+    private LocalDate removalDate;
+}

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.problem.domain;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface QueryProblemRepository {
+
+    QueryProblem save(final QueryProblem queryProblem);
+
+    Optional<QueryProblem> findById(final UUID id);
+}

--- a/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
@@ -1,5 +1,5 @@
 package com.first.flash.climbing.problem.domain.dto;
 
-public record ProblemCreateRequestDto(String imageUrl, String difficulty ) {
+public record ProblemCreateRequestDto(String imageUrl, String difficulty) {
 
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.climbing.problem.domain.dto;
+
+public record ProblemCreateRequestDto(String imageUrl, String difficulty ) {
+
+}

--- a/src/main/java/com/first/flash/climbing/problem/domain/vo/DifficultyInfo.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/vo/DifficultyInfo.java
@@ -1,0 +1,20 @@
+package com.first.flash.climbing.problem.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DifficultyInfo {
+
+    private String difficultyName;
+    private Integer level;
+
+    public static DifficultyInfo of(final String difficultyName, final Integer level) {
+        return new DifficultyInfo(difficultyName, level);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemJpaRepository.java
@@ -1,0 +1,13 @@
+package com.first.flash.climbing.problem.infrastructure;
+
+import com.first.flash.climbing.problem.domain.Problem;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProblemJpaRepository extends JpaRepository<Problem, UUID> {
+
+    Problem save(final Problem problem);
+
+    Optional<Problem> findById(final UUID id);
+}

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.first.flash.climbing.problem.infrastructure;
+
+import com.first.flash.climbing.problem.domain.Problem;
+import com.first.flash.climbing.problem.domain.ProblemRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProblemRepositoryImpl implements ProblemRepository {
+
+    private final ProblemJpaRepository jpaRepository;
+
+    @Override
+    public Problem save(final Problem problem) {
+        return jpaRepository.save(problem);
+    }
+
+    @Override
+    public Optional<Problem> findById(final UUID id) {
+        return jpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
@@ -1,0 +1,13 @@
+package com.first.flash.climbing.problem.infrastructure;
+
+import com.first.flash.climbing.problem.domain.QueryProblem;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QueryProblemJpaRepository extends JpaRepository<QueryProblem, UUID> {
+
+    QueryProblem save(final QueryProblem queryProblem);
+
+    Optional<QueryProblem> findById(final UUID id);
+}

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.first.flash.climbing.problem.infrastructure;
+
+import com.first.flash.climbing.problem.domain.QueryProblem;
+import com.first.flash.climbing.problem.domain.QueryProblemRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QueryProblemRepositoryImpl implements QueryProblemRepository {
+
+    private final QueryProblemJpaRepository jpaRepository;
+
+    @Override
+    public QueryProblem save(final QueryProblem queryProblem) {
+        return jpaRepository.save(queryProblem);
+    }
+
+    @Override
+    public Optional<QueryProblem> findById(final UUID id) {
+        return jpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -1,0 +1,28 @@
+package com.first.flash.climbing.problem.ui;
+
+import com.first.flash.climbing.problem.application.ProblemsSaveService;
+import com.first.flash.climbing.problem.application.dto.ProblemCreateResponseDto;
+import com.first.flash.climbing.problem.domain.dto.ProblemCreateRequestDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ProblemController {
+
+    private final ProblemsSaveService problemsSaveService;
+
+    @PostMapping("/gyms/{gymId}/sectors/{sectorId}/problems")
+    public ResponseEntity<ProblemCreateResponseDto> saveProblems(
+        @PathVariable("gymId") final Long gymId,
+        @PathVariable("sectorId") final Long sectorId,
+        @RequestBody ProblemCreateRequestDto requestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(problemsSaveService.saveProblems(gymId, sectorId, requestDto));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -21,7 +21,7 @@ public class ProblemController {
     public ResponseEntity<ProblemCreateResponseDto> saveProblems(
         @PathVariable("gymId") final Long gymId,
         @PathVariable("sectorId") final Long sectorId,
-        @RequestBody ProblemCreateRequestDto requestDto) {
+        @RequestBody final ProblemCreateRequestDto requestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
                              .body(problemsSaveService.saveProblems(gymId, sectorId, requestDto));
     }

--- a/src/test/java/com/first/flash/climbing/problem/domain/ProblemTest.java
+++ b/src/test/java/com/first/flash/climbing/problem/domain/ProblemTest.java
@@ -1,0 +1,22 @@
+package com.first.flash.climbing.problem.domain;
+
+import static com.first.flash.climbing.problem.fixture.ProblemFixture.createDefault;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ProblemTest {
+
+    @Test
+    void 조회수_증가() {
+        // given
+        Problem problem = createDefault();
+        Integer prevViews = problem.getViews();
+
+        // when
+        problem.view();
+
+        // then
+        assertThat(problem.getViews()).isEqualTo(prevViews + 1);
+    }
+}

--- a/src/test/java/com/first/flash/climbing/problem/fixture/ProblemFixture.java
+++ b/src/test/java/com/first/flash/climbing/problem/fixture/ProblemFixture.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.problem.fixture;
 
 import com.first.flash.climbing.problem.domain.Problem;
+import java.util.UUID;
 
 public class ProblemFixture {
 
@@ -9,7 +10,7 @@ public class ProblemFixture {
     private static final Long DEFAULT_SECTOR_ID = 1L;
 
     public static Problem createDefault() {
-        return Problem.createDefault("example.com", false, "difficultyName",
+        return Problem.createDefault(UUID.randomUUID(), "example.com", "difficultyName",
             DEFAULT_DIFFICULTY_LEVEL, DEFAULT_GYM_ID, DEFAULT_SECTOR_ID);
     }
 

--- a/src/test/java/com/first/flash/climbing/problem/fixture/ProblemFixture.java
+++ b/src/test/java/com/first/flash/climbing/problem/fixture/ProblemFixture.java
@@ -1,0 +1,16 @@
+package com.first.flash.climbing.problem.fixture;
+
+import com.first.flash.climbing.problem.domain.Problem;
+
+public class ProblemFixture {
+
+    private static final Integer DEFAULT_DIFFICULTY_LEVEL = 1;
+    private static final Long DEFAULT_GYM_ID = 1L;
+    private static final Long DEFAULT_SECTOR_ID = 1L;
+
+    public static Problem createDefault() {
+        return Problem.createDefault("example.com", false, "difficultyName",
+            DEFAULT_DIFFICULTY_LEVEL, DEFAULT_GYM_ID, DEFAULT_SECTOR_ID);
+    }
+
+}


### PR DESCRIPTION
# 문제 업로드 API
## Request
```
{
  imageUrl: string,
  difficulty: string
}
```

## Response
```
{
  id: UUID,
  views: int,
  isExpired: bool,
  DifficultyInfo: {
      difficultyName: string,
      level: int
  },
  optionalWeight: long,
  gymId: long,
  sectorId: long
}
```

## 작업 내용
- Problem의 명령 모델, 조회 모델 구분해서 엔티티 생성
- Problem 조회수에 대한 테스트 작성
- Problem 생성 시 조회 모델도 같이 생성
  - 도메인 서비스 객체로 ClimbingGym, Sector 애그리거트를 이용해 Problem 명령/조회 모델 생성