### PR TITLE
해설 조회 및 생성 API 구현

### DIFF
--- a/src/main/java/com/first/flash/climbing/gym/exception/ClimbingGymExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/gym/exception/ClimbingGymExceptionHandler.java
@@ -1,5 +1,30 @@
 package com.first.flash.climbing.gym.exception;
 
+import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
+import com.first.flash.climbing.gym.exception.exceptions.DifficultyNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
 public class ClimbingGymExceptionHandler {
 
+    @ExceptionHandler(ClimbingGymNotFoundException.class)
+    public ResponseEntity<String> handleClimbingGymNotFoundException(
+        final ClimbingGymNotFoundException exception) {
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
+    }
+
+    @ExceptionHandler(DifficultyNotFoundException.class)
+    public ResponseEntity<String> handleDifficultyNotFoundException(
+        final DifficultyNotFoundException exception) {
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
+    }
+
+    private ResponseEntity<String> getResponseWithStatus(final HttpStatus httpStatus,
+        final RuntimeException exception) {
+        return ResponseEntity.status(httpStatus)
+            .body(exception.getMessage());
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -23,7 +23,7 @@ public class SolutionService {
         return SolutionResponseDto.toDto(solutionRepository.save(solution));
     }
 
-    public Solution findById(final Long id) {
+    public Solution findSolutionById(final Long id) {
         return solutionRepository.findById(id)
             .orElseThrow(() -> new SolutionNotFoundException(id));
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -1,9 +1,10 @@
 package com.first.flash.climbing.solution.application;
 
+import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
-import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,9 +30,11 @@ public class SolutionService {
             .orElseThrow(() -> new SolutionNotFoundException(id));
     }
 
-    public List<SolutionResponseDto> findAllSolutionsByProblemId(final Long problemId) {
-        return solutionRepository.findAllByProblemId(problemId).stream()
+    public SolutionsResponseDto findAllSolutionsByProblemId(final Long problemId) {
+        List<SolutionResponseDto> solutions = solutionRepository.findAllByProblemId(problemId)
+            .stream()
             .map(SolutionResponseDto::toDto)
             .toList();
+        return new SolutionsResponseDto(solutions, new SolutionsResponseDto.Meta(solutions.size()));
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.application;
 
+import com.first.flash.climbing.solution.application.dto.SolutionMetaResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.Solution;
@@ -35,6 +36,6 @@ public class SolutionService {
             .stream()
             .map(SolutionResponseDto::toDto)
             .toList();
-        return new SolutionsResponseDto(solutions, new SolutionsResponseDto.Meta(solutions.size()));
+        return new SolutionsResponseDto(solutions, new SolutionMetaResponseDto(solutions.size()));
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -4,6 +4,7 @@ import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,5 +21,10 @@ public class SolutionService {
         final SolutionCreateRequestDto createRequestDto) {
         Solution solution = Solution.of(createRequestDto, problemId);
         return SolutionResponseDto.toDto(solutionRepository.save(solution));
+    }
+
+    public Solution findById(final Long id) {
+        return solutionRepository.findById(id)
+            .orElseThrow(() -> new SolutionNotFoundException(id));
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -5,6 +5,7 @@ import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,5 +27,11 @@ public class SolutionService {
     public Solution findSolutionById(final Long id) {
         return solutionRepository.findById(id)
             .orElseThrow(() -> new SolutionNotFoundException(id));
+    }
+
+    public List<SolutionResponseDto> findAllSolutionsByProblemId(final Long problemId) {
+        return solutionRepository.findAllByProblemId(problemId).stream()
+            .map(SolutionResponseDto::toDto)
+            .toList();
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -1,0 +1,24 @@
+package com.first.flash.climbing.solution.application;
+
+import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.domain.SolutionRepository;
+import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SolutionService {
+
+    private final SolutionRepository solutionRepository;
+
+    @Transactional
+    public SolutionResponseDto saveSolution(final Long problemId,
+        final SolutionCreateRequestDto createRequestDto) {
+        Solution solution = Solution.of(createRequestDto, problemId);
+        return SolutionResponseDto.toDto(solutionRepository.save(solution));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionMetaResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionMetaResponseDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.climbing.solution.application.dto;
+
+public record SolutionMetaResponseDto(int count) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
@@ -1,4 +1,4 @@
-package com.first.flash.climbing.solution.domain.dto;
+package com.first.flash.climbing.solution.application.dto;
 
 import com.first.flash.climbing.solution.domain.Solution;
 

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
@@ -5,7 +5,7 @@ import com.first.flash.climbing.solution.domain.Solution;
 public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
                                   String videoUrl) {
 
-    public static SolutionResponseDto toDto(Solution solution) {
+    public static SolutionResponseDto toDto(final Solution solution) {
         return new SolutionResponseDto(solution.getId(), solution.getUploader(),
             solution.getReview(), solution.getInstagramId(), solution.getVideoUrl());
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
@@ -1,12 +1,15 @@
 package com.first.flash.climbing.solution.application.dto;
 
 import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
 
 public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
                                   String videoUrl) {
 
     public static SolutionResponseDto toDto(final Solution solution) {
-        return new SolutionResponseDto(solution.getId(), solution.getUploader(),
-            solution.getReview(), solution.getInstagramId(), solution.getVideoUrl());
+        SolutionDetail detail = solution.getSolutionDetail();
+
+        return new SolutionResponseDto(solution.getId(), detail.getUploader(), detail.getReview(),
+            detail.getInstagramId(), detail.getVideoUrl());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
@@ -1,0 +1,10 @@
+package com.first.flash.climbing.solution.application.dto;
+
+import java.util.List;
+
+public record SolutionsResponseDto(List<SolutionResponseDto> solutions, Meta meta) {
+
+    public static record Meta(int count) {
+
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
@@ -2,9 +2,7 @@ package com.first.flash.climbing.solution.application.dto;
 
 import java.util.List;
 
-public record SolutionsResponseDto(List<SolutionResponseDto> solutions, Meta meta) {
+public record SolutionsResponseDto(List<SolutionResponseDto> solutions,
+                                   SolutionMetaResponseDto meta) {
 
-    public static record Meta(int count) {
-
-    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -1,0 +1,23 @@
+package com.first.flash.climbing.solution.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class Solution {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String uploader;
+    private String review;
+    private String instagramId;
+    private long optionalWeight;
+    private long problemId;
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.solution.domain;
 
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -20,20 +21,14 @@ public class Solution {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String uploader;
-    private String review;
-    private String instagramId;
-    private String videoUrl;
+    SolutionDetail solutionDetail;
     private Long optionalWeight;
     private Long problemId;
 
-    protected Solution(String uploader, String review, String instagramId, String videoUrl,
-        long problemId) {
-        
-        this.uploader = uploader;
-        this.review = review;
-        this.instagramId = instagramId;
-        this.videoUrl = videoUrl;
+    protected Solution(final String uploader, final String review, final String instagramId,
+        final String videoUrl, final Long problemId) {
+
+        this.solutionDetail = SolutionDetail.of(uploader, review, instagramId, videoUrl);
         this.optionalWeight = DEFAULT_OPTIONAL_WEIGHT;
         this.problemId = problemId;
     }

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.domain;
 
+import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -18,6 +19,22 @@ public class Solution {
     private String uploader;
     private String review;
     private String instagramId;
+    private String videoUrl;
     private long optionalWeight;
     private long problemId;
+
+    protected Solution(String uploader, String review, String instagramId, String videoUrl,
+        long problemId) {
+        this.uploader = uploader;
+        this.review = review;
+        this.instagramId = instagramId;
+        this.videoUrl = videoUrl;
+        this.optionalWeight = 0L;
+        this.problemId = problemId;
+    }
+
+    public static Solution of(SolutionCreateRequestDto createRequestDto, long problemId) {
+        return new Solution(createRequestDto.uploader(), createRequestDto.review(),
+            createRequestDto.instagramId(), createRequestDto.videoUrl(), problemId);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Solution {
 
+    private final Long DEFAULT_OPTIONAL_WEIGHT = 0L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,7 +31,7 @@ public class Solution {
         this.review = review;
         this.instagramId = instagramId;
         this.videoUrl = videoUrl;
-        this.optionalWeight = 0L;
+        this.optionalWeight = DEFAULT_OPTIONAL_WEIGHT;
         this.problemId = problemId;
     }
 

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -24,8 +24,8 @@ public class Solution {
     private String review;
     private String instagramId;
     private String videoUrl;
-    private long optionalWeight;
-    private long problemId;
+    private Long optionalWeight;
+    private Long problemId;
 
     protected Solution(String uploader, String review, String instagramId, String videoUrl,
         long problemId) {

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -15,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Getter
 public class Solution {
 
-    private final Long DEFAULT_OPTIONAL_WEIGHT = 0L;
+    private static final Long DEFAULT_OPTIONAL_WEIGHT = 0L;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -5,11 +5,13 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
 @Getter
 public class Solution {
 

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -29,6 +29,7 @@ public class Solution {
 
     protected Solution(String uploader, String review, String instagramId, String videoUrl,
         long problemId) {
+        
         this.uploader = uploader;
         this.review = review;
         this.instagramId = instagramId;
@@ -37,7 +38,9 @@ public class Solution {
         this.problemId = problemId;
     }
 
-    public static Solution of(SolutionCreateRequestDto createRequestDto, long problemId) {
+    public static Solution of(final SolutionCreateRequestDto createRequestDto,
+        final Long problemId) {
+
         return new Solution(createRequestDto.uploader(), createRequestDto.review(),
             createRequestDto.instagramId(), createRequestDto.videoUrl(), problemId);
     }

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -1,0 +1,13 @@
+package com.first.flash.climbing.solution.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SolutionRepository {
+
+    Solution save(final Solution solution);
+
+    Optional<Solution> findById(final Long id);
+
+    List<Solution> findAll();
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -9,5 +9,5 @@ public interface SolutionRepository {
 
     Optional<Solution> findById(final Long id);
 
-    List<Solution> findAll();
+    List<Solution> findAllByProblemId(final Long problemId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
@@ -1,0 +1,6 @@
+package com.first.flash.climbing.solution.domain.dto;
+
+public record SolutionCreateRequestDto(String videoUrl, String uploader, String review,
+                                       String instagramId) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionResponseDto.java
@@ -1,0 +1,12 @@
+package com.first.flash.climbing.solution.domain.dto;
+
+import com.first.flash.climbing.solution.domain.Solution;
+
+public record SolutionResponseDto(String uploader, String review, String instagramId,
+                                  String videoUrl) {
+
+    public static SolutionResponseDto toDto(Solution solution) {
+        return new SolutionResponseDto(solution.getUploader(), solution.getReview(),
+            solution.getInstagramId(), solution.getVideoUrl());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionResponseDto.java
@@ -2,11 +2,11 @@ package com.first.flash.climbing.solution.domain.dto;
 
 import com.first.flash.climbing.solution.domain.Solution;
 
-public record SolutionResponseDto(String uploader, String review, String instagramId,
+public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
                                   String videoUrl) {
 
     public static SolutionResponseDto toDto(Solution solution) {
-        return new SolutionResponseDto(solution.getUploader(), solution.getReview(),
-            solution.getInstagramId(), solution.getVideoUrl());
+        return new SolutionResponseDto(solution.getId(), solution.getUploader(),
+            solution.getReview(), solution.getInstagramId(), solution.getVideoUrl());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
@@ -1,0 +1,33 @@
+package com.first.flash.climbing.solution.domain.vo;
+
+import jakarta.persistence.Embeddable;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor
+@EqualsAndHashCode
+@Getter
+public class SolutionDetail {
+
+    private String uploader;
+    private String review;
+    private String instagramId;
+    private String videoUrl;
+
+    protected SolutionDetail(final String uploader, final String review, final String instagramId,
+        final String videoUrl) {
+
+        this.uploader = uploader;
+        this.review = review;
+        this.instagramId = instagramId;
+        this.videoUrl = videoUrl;
+    }
+
+    public static SolutionDetail of(final String uploader, final String review,
+        final String instagramId, final String videoUrl) {
+
+        return new SolutionDetail(uploader, review, instagramId, videoUrl);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.first.flash.climbing.solution.exception;
+
+import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class SolutionExceptionHandler {
+
+    @ExceptionHandler(SolutionNotFoundException.class)
+    public ResponseEntity<String> handleSectorNotFoundException(
+        final SolutionNotFoundException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(exception.getMessage());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionNotFoundException.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionNotFoundException.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.solution.exception.exceptions;
+
+public class SolutionNotFoundException extends RuntimeException {
+
+    public SolutionNotFoundException(final Long id) {
+        super(String.format("아이디가 %s인 해설을 찾을 수 없습니다.", id));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
@@ -1,0 +1,15 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import com.first.flash.climbing.solution.domain.Solution;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolutionJpaRepository extends JpaRepository<Solution, Long> {
+
+    Solution save(final Solution solution);
+
+    Optional<Solution> findById(final long id);
+
+    List<Solution> findAll();
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
@@ -11,5 +11,5 @@ public interface SolutionJpaRepository extends JpaRepository<Solution, Long> {
 
     Optional<Solution> findById(final long id);
 
-    List<Solution> findAll();
+    List<Solution> findByProblemId(Long problemId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
@@ -9,7 +9,7 @@ public interface SolutionJpaRepository extends JpaRepository<Solution, Long> {
 
     Solution save(final Solution solution);
 
-    Optional<Solution> findById(final long id);
+    Optional<Solution> findById(final Long id);
 
-    List<Solution> findByProblemId(Long problemId);
+    List<Solution> findByProblemId(final Long problemId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -24,7 +24,7 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     }
 
     @Override
-    public List<Solution> findAllByProblemId(Long problemId) {
+    public List<Solution> findAllByProblemId(final Long problemId) {
         return solutionJpaRepository.findByProblemId(problemId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.domain.SolutionRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SolutionRepositoryImpl implements SolutionRepository {
+
+    private final SolutionJpaRepository solutionJpaRepository;
+
+    @Override
+    public Solution save(final Solution solution) {
+        return solutionJpaRepository.save(solution);
+    }
+
+    @Override
+    public Optional<Solution> findById(final Long id) {
+        return solutionJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Solution> findAll() {
+        return solutionJpaRepository.findAll();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -24,7 +24,7 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     }
 
     @Override
-    public List<Solution> findAll() {
-        return solutionJpaRepository.findAll();
+    public List<Solution> findAllByProblemId(Long problemId) {
+        return solutionJpaRepository.findByProblemId(problemId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -1,9 +1,9 @@
 package com.first.flash.climbing.solution.ui;
 
 import com.first.flash.climbing.solution.application.SolutionService;
+import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
-import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,8 +22,8 @@ public class SolutionController {
     private final SolutionService solutionService;
 
     @GetMapping("problems/{problemId}/solutions")
-    public ResponseEntity<List<SolutionResponseDto>> getSolutions(@PathVariable Long problemId) {
-        List<SolutionResponseDto> response = solutionService.findAllSolutionsByProblemId(
+    public ResponseEntity<SolutionsResponseDto> getSolutions(@PathVariable Long problemId) {
+        SolutionsResponseDto response = solutionService.findAllSolutionsByProblemId(
             problemId);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -22,15 +22,17 @@ public class SolutionController {
     private final SolutionService solutionService;
 
     @GetMapping("problems/{problemId}/solutions")
-    public ResponseEntity<SolutionsResponseDto> getSolutions(@PathVariable Long problemId) {
+    public ResponseEntity<SolutionsResponseDto> getSolutions(@PathVariable final Long problemId) {
         SolutionsResponseDto response = solutionService.findAllSolutionsByProblemId(
             problemId);
+
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("problems/{problemId}/solutions")
     public ResponseEntity<SolutionResponseDto> createSolution(@PathVariable final Long problemId,
         @RequestBody final SolutionCreateRequestDto solutionCreateRequestDto) {
+
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(solutionService.saveSolution(problemId, solutionCreateRequestDto));
     }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -3,9 +3,11 @@ package com.first.flash.climbing.solution.ui;
 import com.first.flash.climbing.solution.application.SolutionService;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +20,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class SolutionController {
 
     private final SolutionService solutionService;
+
+    @GetMapping("problems/{problemId}/solutions")
+    public ResponseEntity<List<SolutionResponseDto>> getSolutions(@PathVariable Long problemId) {
+        List<SolutionResponseDto> response = solutionService.findAllSolutionsByProblemId(
+            problemId);
+        return ResponseEntity.ok(response);
+    }
 
     @PostMapping("problems/{problemId}/solutions")
     public ResponseEntity<SolutionResponseDto> createSolution(@PathVariable final Long problemId,

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -1,0 +1,28 @@
+package com.first.flash.climbing.solution.ui;
+
+import com.first.flash.climbing.solution.application.SolutionService;
+import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class SolutionController {
+
+    private final SolutionService solutionService;
+
+    @PostMapping("problems/{problemId}/solutions")
+    public ResponseEntity<SolutionResponseDto> createSolution(@PathVariable final Long problemId,
+        @RequestBody final SolutionCreateRequestDto solutionCreateRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(solutionService.saveSolution(problemId, solutionCreateRequestDto));
+    }
+}

--- a/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
@@ -4,10 +4,11 @@ import static com.first.flash.climbing.solution.fixture.SolutionFixture.createDe
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
-import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import com.first.flash.climbing.solution.infrastructure.FakeSolutionRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,5 +69,30 @@ class SolutionServiceTest {
         // when & then
         assertThatThrownBy(() -> solutionService.findSolutionById(NON_EXISTENT_SOLUTION_ID))
             .isInstanceOf(SolutionNotFoundException.class);
+    }
+
+    @Test
+    void 문제_ID로_해설_목록_찾기() {
+        // given
+        SolutionCreateRequestDto createRequestDto1 = createDefaultRequestDto();
+        SolutionCreateRequestDto createRequestDto2 = createDefaultRequestDto();
+        solutionService.saveSolution(DEFAULT_PROBLEM_ID, createRequestDto1);
+        solutionService.saveSolution(DEFAULT_PROBLEM_ID, createRequestDto2);
+
+        // when
+        SolutionsResponseDto solutionsResponse = solutionService.findAllSolutionsByProblemId(
+            DEFAULT_PROBLEM_ID);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(solutionsResponse).isNotNull();
+            softly.assertThat(solutionsResponse.solutions()).hasSize(2);
+            softly.assertThat(solutionsResponse.meta().count()).isEqualTo(2);
+
+            softly.assertThat(solutionsResponse.solutions().get(0).instagramId())
+                .isEqualTo(createRequestDto1.instagramId());
+            softly.assertThat(solutionsResponse.solutions().get(1).instagramId())
+                .isEqualTo(createRequestDto2.instagramId());
+        });
     }
 }

--- a/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
@@ -41,7 +41,6 @@ class SolutionServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(saveDto).isNotNull();
             softly.assertThat(saveDto.id()).isNotNull();
-            softly.assertThat(saveDto.instagramId()).isEqualTo(createRequestDto.instagramId());
         });
     }
 
@@ -58,8 +57,6 @@ class SolutionServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(foundSolution).isNotNull();
-            softly.assertThat(foundSolution.getInstagramId())
-                .isEqualTo(createRequestDto.instagramId());
             softly.assertThat(foundSolution.getProblemId()).isEqualTo(DEFAULT_PROBLEM_ID);
         });
     }
@@ -88,11 +85,6 @@ class SolutionServiceTest {
             softly.assertThat(solutionsResponse).isNotNull();
             softly.assertThat(solutionsResponse.solutions()).hasSize(2);
             softly.assertThat(solutionsResponse.meta().count()).isEqualTo(2);
-
-            softly.assertThat(solutionsResponse.solutions().get(0).instagramId())
-                .isEqualTo(createRequestDto1.instagramId());
-            softly.assertThat(solutionsResponse.solutions().get(1).instagramId())
-                .isEqualTo(createRequestDto2.instagramId());
         });
     }
 }

--- a/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
@@ -1,0 +1,72 @@
+package com.first.flash.climbing.solution.application;
+
+import static com.first.flash.climbing.solution.fixture.SolutionFixture.createDefaultRequestDto;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.domain.SolutionRepository;
+import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
+import com.first.flash.climbing.solution.infrastructure.FakeSolutionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class SolutionServiceTest {
+
+    private final static Long DEFAULT_PROBLEM_ID = 1L;
+    private final static Long NON_EXISTENT_SOLUTION_ID = 999L;
+
+    private SolutionRepository solutionRepository;
+    private SolutionService solutionService;
+
+    @BeforeEach
+    void init() {
+        solutionRepository = new FakeSolutionRepository();
+        solutionService = new SolutionService(solutionRepository);
+    }
+
+    @Test
+    void 해설_저장() {
+        // given
+        SolutionCreateRequestDto createRequestDto = createDefaultRequestDto();
+
+        // when
+        SolutionResponseDto saveDto = solutionService.saveSolution(DEFAULT_PROBLEM_ID,
+            createRequestDto);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(saveDto).isNotNull();
+            softly.assertThat(saveDto.id()).isNotNull();
+            softly.assertThat(saveDto.instagramId()).isEqualTo(createRequestDto.instagramId());
+        });
+    }
+
+    @Test
+    void 아이디로_해설_찾기_성공() {
+        // given
+        SolutionCreateRequestDto createRequestDto = createDefaultRequestDto();
+        SolutionResponseDto saveDto = solutionService.saveSolution(DEFAULT_PROBLEM_ID,
+            createRequestDto);
+
+        // when
+        Solution foundSolution = solutionService.findById(saveDto.id());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(foundSolution).isNotNull();
+            softly.assertThat(foundSolution.getInstagramId())
+                .isEqualTo(createRequestDto.instagramId());
+            softly.assertThat(foundSolution.getProblemId()).isEqualTo(DEFAULT_PROBLEM_ID);
+        });
+    }
+
+    @Test
+    void 아이디로_해설_찾기_실패() {
+        // when & then
+        assertThatThrownBy(() -> solutionService.findById(NON_EXISTENT_SOLUTION_ID))
+            .isInstanceOf(SolutionNotFoundException.class);
+    }
+}

--- a/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
+++ b/src/test/java/com/first/flash/climbing/solution/application/SolutionServiceTest.java
@@ -52,7 +52,7 @@ class SolutionServiceTest {
             createRequestDto);
 
         // when
-        Solution foundSolution = solutionService.findById(saveDto.id());
+        Solution foundSolution = solutionService.findSolutionById(saveDto.id());
 
         // then
         assertSoftly(softly -> {
@@ -66,7 +66,7 @@ class SolutionServiceTest {
     @Test
     void 아이디로_해설_찾기_실패() {
         // when & then
-        assertThatThrownBy(() -> solutionService.findById(NON_EXISTENT_SOLUTION_ID))
+        assertThatThrownBy(() -> solutionService.findSolutionById(NON_EXISTENT_SOLUTION_ID))
             .isInstanceOf(SolutionNotFoundException.class);
     }
 }

--- a/src/test/java/com/first/flash/climbing/solution/fixture/SolutionFixture.java
+++ b/src/test/java/com/first/flash/climbing/solution/fixture/SolutionFixture.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.solution.fixture;
+
+import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+
+public class SolutionFixture {
+
+    public static SolutionCreateRequestDto createDefaultRequestDto() {
+        return new SolutionCreateRequestDto("default_url.mp4", "uploader",
+            "review content", "@instagram_id");
+    }
+}

--- a/src/test/java/com/first/flash/climbing/solution/infrastructure/FakeSolutionRepository.java
+++ b/src/test/java/com/first/flash/climbing/solution/infrastructure/FakeSolutionRepository.java
@@ -2,7 +2,6 @@ package com.first.flash.climbing.solution.infrastructure;
 
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +32,9 @@ public class FakeSolutionRepository implements SolutionRepository {
     }
 
     @Override
-    public List<Solution> findAll() {
-        return new ArrayList<>(db.values());
+    public List<Solution> findAllByProblemId(Long problemId) {
+        return db.values().stream()
+            .filter(solution -> solution.getProblemId().equals(problemId))
+            .toList();
     }
 }

--- a/src/test/java/com/first/flash/climbing/solution/infrastructure/FakeSolutionRepository.java
+++ b/src/test/java/com/first/flash/climbing/solution/infrastructure/FakeSolutionRepository.java
@@ -1,0 +1,39 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.domain.SolutionRepository;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public class FakeSolutionRepository implements SolutionRepository {
+
+    private final static Long DEFAULT_OPTIONAL_WEIGHT = 0L;
+    private final static Long DEFAULT_PROBLEM_ID = 1L;
+
+    final private Map<Long, Solution> db = new HashMap<>();
+    private Long id = 0L;
+
+
+    @Override
+    public Solution save(Solution solution) {
+        Solution savedSolution = new Solution(id++, solution.getUploader(), solution.getReview(),
+            solution.getInstagramId(), solution.getVideoUrl(), DEFAULT_OPTIONAL_WEIGHT,
+            DEFAULT_PROBLEM_ID);
+
+        db.put(savedSolution.getId(), savedSolution);
+        return savedSolution;
+    }
+
+    @Override
+    public Optional<Solution> findById(Long id) {
+        return Optional.ofNullable(db.get(id));
+    }
+
+    @Override
+    public List<Solution> findAll() {
+        return new ArrayList<>(db.values());
+    }
+}

--- a/src/test/java/com/first/flash/climbing/solution/infrastructure/FakeSolutionRepository.java
+++ b/src/test/java/com/first/flash/climbing/solution/infrastructure/FakeSolutionRepository.java
@@ -18,8 +18,8 @@ public class FakeSolutionRepository implements SolutionRepository {
 
     @Override
     public Solution save(Solution solution) {
-        Solution savedSolution = new Solution(id++, solution.getUploader(), solution.getReview(),
-            solution.getInstagramId(), solution.getVideoUrl(), DEFAULT_OPTIONAL_WEIGHT,
+        Solution savedSolution = new Solution(id++, solution.getSolutionDetail(),
+            DEFAULT_OPTIONAL_WEIGHT,
             DEFAULT_PROBLEM_ID);
 
         db.put(savedSolution.getId(), savedSolution);


### PR DESCRIPTION
해설 영상 조회 및 해설 업로드 API를 구현했습니다.

## 해설 업로드

### 요약

해설(영상, 업로더명, 리뷰, 인스타id)를 업로드하는 API

### 세부사항

- 영상 업로드 기능은 구현 예정이기 때문에 우선 영상 데이터를 받는 대신 url만 받도록 구현
- 응답 형식을 위해 `SolutionResponseDto` 사용

### 예시
- request: `POST /problems/1/solutions`
```json
{
    "videoUrl": "videoUrl.mp4",
    "uploader": "wonyang",
    "review": "쉬워요!",
    "instagramId": "koesnnow"
}

```
- response: 201 CREATED
```json
{
    "id": 2,
    "uploader": "wonyang",
    "review": "쉬워요!",
    "instagramId": "koesnnow",
    "videoUrl": "videoUrl.mp4"
}
```

## 해설 조회

### 요약

문제 id(problemId)에 해당하는 모든 해설을 조회하는 API

### 세부사항

- 응답 형식을 위해 `SolutionResponseDto`을 wrapping한 `SolutionsResponseDto` 사용

### 예시
- request: `GET /problems/{problemId}/solutions`
- response: 200 OK
```json
{
    "solutions": [
        {
            "id": 1,
            "uploader": "wonyang",
            "review": "쉬워요!",
            "instagramId": "koesnnow",
            "videoUrl": "videoUrl.mp4"
        },
        {
            "id": 2,
            "uploader": "wonyang",
            "review": "쉬워요!",
            "instagramId": "koesnnow",
            "videoUrl": "videoUrl.mp4"
        }
    ],
    "meta": {
        "count": 2
    }
}
```

- meta#count는 해설의 총 개수 정보

## 기타 수정 사항

- ClimbingGym 애그리거트에 ErrorHandling 로직이 누락되어 있던 부분 수정