### PR TITLE
Swagger 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,41 +1,44 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.1'
-	id 'io.spring.dependency-management' version '1.1.5'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.1'
+    id 'io.spring.dependency-management' version '1.1.5'
 }
 
 group = 'com.first'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// db
-	runtimeOnly 'com.h2database:h2'
-	runtimeOnly 'com.mysql:mysql-connector-j'
+    // db
+    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/src/main/java/com/first/flash/climbing/SwaggerConfig.java
+++ b/src/main/java/com/first/flash/climbing/SwaggerConfig.java
@@ -1,0 +1,20 @@
+package com.first.flash.climbing;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("Flash API docs")
+                .version("1.0.0")
+                .description(
+                    "Flash 서비스의 API document입니다."));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -5,6 +5,10 @@ import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,6 +20,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "gyms", description = "클라이밍장 조회 API")
 @RestController
 @RequestMapping("/gyms")
 @RequiredArgsConstructor
@@ -23,12 +28,20 @@ public class ClimbingGymController {
 
     private final ClimbingGymService climbingGymService;
 
+    @Operation(summary = "모든 클라이밍장 조회", description = "모든 클라이밍장을 리스트로 반환")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "클라이밍장 리스트 조회 성공함")
+    })
     @GetMapping
     public List<ClimbingGymResponseDto> getGyms() {
         return climbingGymService.findAllClimbingGyms().stream()
             .toList();
     }
 
+    @Operation(summary = "클라이밍장 생성", description = "새로운 클라이밍장 생성")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "성공적으로 클라이밍장을 생성함"),
+    })
     @PostMapping
     public ResponseEntity<ClimbingGymCreateResponseDto> createGym(
         @RequestBody final ClimbingGymCreateRequestDto gymCreateRequestDto) {
@@ -36,6 +49,11 @@ public class ClimbingGymController {
             .body(climbingGymService.save(gymCreateRequestDto));
     }
 
+    @Operation(summary = "클라이밍장 정보 조회", description = "특정 클라이밍장의 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 클라이밍장 정보를 조회함"),
+        @ApiResponse(responseCode = "404", description = "클라이밍장을 찾을 수 없음")
+    })
     @GetMapping("/{gymId}")
     public ClimbingGym getGymDetails(@PathVariable final Long gymId) {
         return climbingGymService.findClimbingGymById(gymId);

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -3,6 +3,10 @@ package com.first.flash.climbing.problem.ui;
 import com.first.flash.climbing.problem.application.ProblemsSaveService;
 import com.first.flash.climbing.problem.application.dto.ProblemCreateResponseDto;
 import com.first.flash.climbing.problem.domain.dto.ProblemCreateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,18 +15,23 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "problems", description = "문제 관리 API")
 @RestController
 @RequiredArgsConstructor
 public class ProblemController {
 
     private final ProblemsSaveService problemsSaveService;
 
+    @Operation(summary = "문제 업로드", description = "특정 섹터에 문제 업로드")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "성공적으로 문제를 업로드함"),
+    })
     @PostMapping("/gyms/{gymId}/sectors/{sectorId}/problems")
     public ResponseEntity<ProblemCreateResponseDto> saveProblems(
         @PathVariable("gymId") final Long gymId,
         @PathVariable("sectorId") final Long sectorId,
         @RequestBody final ProblemCreateRequestDto requestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(problemsSaveService.saveProblems(gymId, sectorId, requestDto));
+            .body(problemsSaveService.saveProblems(gymId, sectorId, requestDto));
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -25,6 +25,7 @@ public class ProblemController {
     @Operation(summary = "문제 업로드", description = "특정 섹터에 문제 업로드")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "성공적으로 문제를 업로드함"),
+        @ApiResponse(responseCode = "404", description = "난이도를 찾을 수 없음")
     })
     @PostMapping("/gyms/{gymId}/sectors/{sectorId}/problems")
     public ResponseEntity<ProblemCreateResponseDto> saveProblems(

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -3,10 +3,6 @@ package com.first.flash.climbing.problem.ui;
 import com.first.flash.climbing.problem.application.ProblemsSaveService;
 import com.first.flash.climbing.problem.application.dto.ProblemCreateResponseDto;
 import com.first.flash.climbing.problem.domain.dto.ProblemCreateRequestDto;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,18 +11,12 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "problems", description = "문제 관리 API")
 @RestController
 @RequiredArgsConstructor
 public class ProblemController {
 
     private final ProblemsSaveService problemsSaveService;
 
-    @Operation(summary = "문제 업로드", description = "특정 섹터에 문제 업로드")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "성공적으로 문제를 업로드함"),
-        @ApiResponse(responseCode = "404", description = "난이도를 찾을 수 없음")
-    })
     @PostMapping("/gyms/{gymId}/sectors/{sectorId}/problems")
     public ResponseEntity<ProblemCreateResponseDto> saveProblems(
         @PathVariable("gymId") final Long gymId,

--- a/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
+++ b/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
@@ -2,8 +2,12 @@ package com.first.flash.climbing.sector.ui;
 
 import com.first.flash.climbing.sector.application.SectorService;
 import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
-import com.first.flash.climbing.sector.application.dto.SectorWriteDetailResponseDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRemovalDateRequestDto;
+import com.first.flash.climbing.sector.application.dto.SectorWriteDetailResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "sectors", description = "섹터 관리 API")
 @RestController
 @RequestMapping
 @RequiredArgsConstructor
@@ -21,13 +26,24 @@ public class SectorController {
 
     private final SectorService sectorService;
 
+    @Operation(summary = "섹터 갱신(생성)", description = "특정 클라이밍장에 새로운 섹터 생성")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "성공적으로 섹터를 생성함"),
+        @ApiResponse(responseCode = "400", description = "탈거일이 세팅일보다 빠름")
+    })
     @PostMapping("gyms/{gymId}/sectors")
     public ResponseEntity<SectorWriteDetailResponseDto> createSector(@PathVariable final Long gymId,
         @RequestBody final SectorCreateRequestDto sectorCreateRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(sectorService.saveSector(gymId, sectorCreateRequestDto));
+            .body(sectorService.saveSector(gymId, sectorCreateRequestDto));
     }
 
+    @Operation(summary = "섹터 탈거일 수정", description = "특정 섹터의 탈거일 수정")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 섹터 탈거일을 수정함"),
+        @ApiResponse(responseCode = "400", description = "탈거일이 세팅일보다 빠름"),
+        @ApiResponse(responseCode = "404", description = "섹터를 찾을 수 없음")
+    })
     @PatchMapping("sectors/{sectorId}")
     public ResponseEntity<SectorWriteDetailResponseDto> updateSectorRemovalDate(
         @PathVariable final Long sectorId,

--- a/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class SolutionExceptionHandler {
 
     @ExceptionHandler(SolutionNotFoundException.class)
-    public ResponseEntity<String> handleSectorNotFoundException(
+    public ResponseEntity<String> handleSolutionNotFoundException(
         final SolutionNotFoundException exception) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
             .body(exception.getMessage());

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -4,6 +4,10 @@ import com.first.flash.climbing.solution.application.SolutionService;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +18,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "solutions", description = "해설 영상 관리 API")
 @RestController
 @RequestMapping
 @RequiredArgsConstructor
@@ -21,6 +26,10 @@ public class SolutionController {
 
     private final SolutionService solutionService;
 
+    @Operation(summary = "해설 영상 조회", description = "특정 문제에 대한 해설 영상 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 해설 영상을 조회함")
+    })
     @GetMapping("problems/{problemId}/solutions")
     public ResponseEntity<SolutionsResponseDto> getSolutions(@PathVariable final Long problemId) {
         SolutionsResponseDto response = solutionService.findAllSolutionsByProblemId(
@@ -29,6 +38,10 @@ public class SolutionController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "해설 영상 업로드", description = "특정 문제에 대한 해설 영상 업로드")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "성공적으로 해설 영상을 업로드함")
+    })
     @PostMapping("problems/{problemId}/solutions")
     public ResponseEntity<SolutionResponseDto> createSolution(@PathVariable final Long problemId,
         @RequestBody final SolutionCreateRequestDto solutionCreateRequestDto) {

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -28,7 +28,8 @@ public class SolutionController {
 
     @Operation(summary = "해설 영상 조회", description = "특정 문제에 대한 해설 영상 조회")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "성공적으로 해설 영상을 조회함")
+        @ApiResponse(responseCode = "200", description = "성공적으로 해설 영상을 조회함"),
+        @ApiResponse(responseCode = "404", description = "해설을 찾을 수 없음")
     })
     @GetMapping("problems/{problemId}/solutions")
     public ResponseEntity<SolutionsResponseDto> getSolutions(@PathVariable final Long problemId) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,16 @@
 server.port=8080
 spring.application.name=flash
-
 spring.datasource.url=${DB_URL}
 spring.datasource.driverClassName=${DB_DRIVER_CLASS}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=${DB_DDL_AUTO}
 spring.jpa.show-sql=true
+# Swagger
+springdoc.api-docs.path=/v1/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operationsSorter=method
+springdoc.swagger-ui.defaultModelExpandDepth=1
+springdoc.swagger-ui.display-request-duration=true
+springdoc.swagger-ui.tryItOutEnabled=true
+springdoc.swagger-ui.deepLinking=true


### PR DESCRIPTION
API 명세 자동화를 위해 Swagger를 세팅하였습니다.

### 접속 방법

1. 서버 실행
2. `/swagger-ui/index.html `로 접속

### Swagger 설명 추가 방법

```java
@Tag(name = "solutions", description = "해설 영상 관리 API")
@RestController
@RequestMapping
@RequiredArgsConstructor
public class SolutionController {

    private final SolutionService solutionService;

    @Operation(summary = "해설 영상 조회", description = "특정 문제에 대한 해설 영상 조회")
    @ApiResponses(value = {
        @ApiResponse(responseCode = "200", description = "성공적으로 해설 영상을 조회함"),
        @ApiResponse(responseCode = "404", description = "해설을 찾을 수 없음")
    })
    @GetMapping("problems/{problemId}/solutions")
    public ResponseEntity<SolutionsResponseDto> getSolutions(@PathVariable final Long problemId) {
        SolutionsResponseDto response = solutionService.findAllSolutionsByProblemId(
            problemId);

        return ResponseEntity.ok(response);
    }
```

- `@Tag`: 해당 세션명과 설명
- `@Operation`: 해당 API 요약과 상세 설명
- `@ApiResponse`: API의 응답 코드와 각 응답 코드에 대한 설명

### 접속 화면

![image](https://github.com/user-attachments/assets/34dc06eb-4fee-4393-876d-bd562d2729a3)
