### PR TITLE
클라이밍장 단건 조회에 섹터 정보 추가

### DIFF
--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -3,9 +3,12 @@ package com.first.flash.climbing.gym.application;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymDetailResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
+import com.first.flash.climbing.gym.domian.vo.Difficulty;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
+import com.first.flash.climbing.gym.exception.exceptions.NoSectorGymException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,12 +29,34 @@ public class ClimbingGymService {
 
     public ClimbingGym findClimbingGymById(final Long id) {
         return climbingGymRepository.findById(id)
-            .orElseThrow(() -> new ClimbingGymNotFoundException(id));
+                                    .orElseThrow(() -> new ClimbingGymNotFoundException(id));
     }
 
     public List<ClimbingGymResponseDto> findAllClimbingGyms() {
         return climbingGymRepository.findAll().stream()
-            .map(ClimbingGymResponseDto::toDto)
-            .toList();
+                                    .map(ClimbingGymResponseDto::toDto)
+                                    .toList();
+    }
+
+    public ClimbingGymDetailResponseDto findClimbingGymDetail(final Long id) {
+        ClimbingGym climbingGym = findClimbingGymById(id);
+        List<String> sectorNames = findSectorNamesById(id);
+        List<String> difficultyNames = getDifficultyNames(climbingGym);
+        return new ClimbingGymDetailResponseDto(climbingGym.getMapImageUrl(),
+            difficultyNames, sectorNames);
+    }
+
+    private List<String> findSectorNamesById(final Long id) {
+        List<String> sectorNames = climbingGymRepository.findGymSectorNamesById(id);
+        if (sectorNames.isEmpty()) {
+            throw new NoSectorGymException(id);
+        }
+        return sectorNames;
+    }
+
+    private List<String> getDifficultyNames(final ClimbingGym climbingGym) {
+        return climbingGym.getDifficulties().stream()
+                          .map(Difficulty::getName)
+                          .toList();
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymDetailResponseDto.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.gym.application.dto;
+
+import java.util.List;
+
+public record ClimbingGymDetailResponseDto(String mapImageUrl, List<String> difficulties,
+                                           List<String> sectors) {
+
+}

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
@@ -10,4 +10,6 @@ public interface ClimbingGymRepository {
     Optional<ClimbingGym> findById(final Long id);
 
     List<ClimbingGym> findAll();
+
+    List<String> findGymSectorNamesById(final Long id);
 }

--- a/src/main/java/com/first/flash/climbing/gym/exception/ClimbingGymExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/gym/exception/ClimbingGymExceptionHandler.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.gym.exception;
 
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
 import com.first.flash.climbing.gym.exception.exceptions.DifficultyNotFoundException;
+import com.first.flash.climbing.gym.exception.exceptions.NoSectorGymException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -22,9 +23,15 @@ public class ClimbingGymExceptionHandler {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
+    @ExceptionHandler(NoSectorGymException.class)
+    public ResponseEntity<String> handleNoSectorGymException(
+        final NoSectorGymException exception) {
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
+    }
+
     private ResponseEntity<String> getResponseWithStatus(final HttpStatus httpStatus,
         final RuntimeException exception) {
         return ResponseEntity.status(httpStatus)
-            .body(exception.getMessage());
+                             .body(exception.getMessage());
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/exception/exceptions/NoSectorGymException.java
+++ b/src/main/java/com/first/flash/climbing/gym/exception/exceptions/NoSectorGymException.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.gym.exception.exceptions;
+
+public class NoSectorGymException extends RuntimeException {
+
+    public NoSectorGymException(final Long id) {
+        super(String.format("아이디가 %d인 클라이밍장엔 섹터가 존재하지 않습니다.", id));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
@@ -15,8 +15,8 @@ public class ClimbingGymQueryDslRepository {
 
     public List<String> findSectorNamesByGymId(final Long gymId) {
         return jpaQueryFactory.select(sector.sectorName.name)
-                                                 .from(sector)
-                                                 .where(sector.gymId.eq(gymId))
-                                                 .fetch();
+                              .from(sector)
+                              .where(sector.gymId.eq(gymId), sector.removalInfo.isExpired.isFalse())
+                              .fetch();
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
@@ -1,0 +1,22 @@
+package com.first.flash.climbing.gym.infrastructure;
+
+import static com.first.flash.climbing.sector.domain.QSector.sector;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ClimbingGymQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<String> findSectorNamesByGymId(final Long gymId) {
+        return jpaQueryFactory.select(sector.sectorName.name)
+                                                 .from(sector)
+                                                 .where(sector.gymId.eq(gymId))
+                                                 .fetch();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class ClimbingGymRepositoryImpl implements ClimbingGymRepository {
 
     private final ClimbingGymJpaRepository climbingGymJpaRepository;
+    private final ClimbingGymQueryDslRepository climbingGymQueryDslRepository;
 
     @Override
     public ClimbingGym save(final ClimbingGym gym) {
@@ -26,5 +27,10 @@ public class ClimbingGymRepositoryImpl implements ClimbingGymRepository {
     @Override
     public List<ClimbingGym> findAll() {
         return climbingGymJpaRepository.findAll();
+    }
+
+    @Override
+    public List<String> findGymSectorNamesById(final Long id) {
+        return climbingGymQueryDslRepository.findSectorNamesByGymId(id);
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -4,7 +4,7 @@ import com.first.flash.climbing.gym.application.ClimbingGymService;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
-import com.first.flash.climbing.gym.domian.ClimbingGym;
+import com.first.flash.climbing.gym.application.dto.ClimbingGymDetailResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -35,7 +35,7 @@ public class ClimbingGymController {
     @GetMapping
     public List<ClimbingGymResponseDto> getGyms() {
         return climbingGymService.findAllClimbingGyms().stream()
-            .toList();
+                                 .toList();
     }
 
     @Operation(summary = "클라이밍장 생성", description = "새로운 클라이밍장 생성")
@@ -46,7 +46,7 @@ public class ClimbingGymController {
     public ResponseEntity<ClimbingGymCreateResponseDto> createGym(
         @RequestBody final ClimbingGymCreateRequestDto gymCreateRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(climbingGymService.save(gymCreateRequestDto));
+                             .body(climbingGymService.save(gymCreateRequestDto));
     }
 
     @Operation(summary = "클라이밍장 정보 조회", description = "특정 클라이밍장의 정보 조회")
@@ -55,7 +55,8 @@ public class ClimbingGymController {
         @ApiResponse(responseCode = "404", description = "클라이밍장을 찾을 수 없음")
     })
     @GetMapping("/{gymId}")
-    public ClimbingGym getGymDetails(@PathVariable final Long gymId) {
-        return climbingGymService.findClimbingGymById(gymId);
+    public ResponseEntity<ClimbingGymDetailResponseDto> getGymDetails(
+        @PathVariable final Long gymId) {
+        return ResponseEntity.ok(climbingGymService.findClimbingGymDetail(gymId));
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -52,7 +52,8 @@ public class ClimbingGymController {
     @Operation(summary = "클라이밍장 정보 조회", description = "특정 클라이밍장의 정보 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공적으로 클라이밍장 정보를 조회함"),
-        @ApiResponse(responseCode = "404", description = "클라이밍장을 찾을 수 없음")
+        @ApiResponse(responseCode = "404", description = "클라이밍장을 찾을 수 없음"),
+        @ApiResponse(responseCode = "404", description = "클라이밍장에 섹터가 없음")
     })
     @GetMapping("/{gymId}")
     public ResponseEntity<ClimbingGymDetailResponseDto> getGymDetails(

--- a/src/test/java/com/first/flash/climbing/gym/infrastructure/FakeClimbingGymRepository.java
+++ b/src/test/java/com/first/flash/climbing/gym/infrastructure/FakeClimbingGymRepository.java
@@ -31,4 +31,9 @@ public class FakeClimbingGymRepository implements ClimbingGymRepository {
     public List<ClimbingGym> findAll() {
         return new ArrayList<>(db.values());
     }
+
+    @Override
+    public List<String> findGymSectorNamesById(final Long id) {
+        return null;
+    }
 }


### PR DESCRIPTION
# 단건 조회 API
## /gyms/{gymId} (GET)
### request
**url param**
```
gymId: long
```

### response
```
{
  mapImageUrl: string,
  difficulties: string[],
  sectors: string[]
}
```
## 작업 내용
- gym repository에서 id를 이용해 해당 클라이밍장에 속한 섹터의 이름들을 반환하는 메서드 생성
- 섹터가 없을 경우 예외처리
