### PR TITLE
섹터와 문제 간 이벤트 처리

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ COPY ${JAR_FILE} app.jar
 
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java","-Duser.timezone=UTC","-jar","/app.jar"]

--- a/src/main/java/com/first/flash/FlashApplication.java
+++ b/src/main/java/com/first/flash/FlashApplication.java
@@ -3,9 +3,11 @@ package com.first.flash;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class FlashApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/first/flash/FlashApplication.java
+++ b/src/main/java/com/first/flash/FlashApplication.java
@@ -2,8 +2,10 @@ package com.first.flash;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class FlashApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.problem.application;
 
+import com.first.flash.climbing.sector.application.SectorExpiredEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
@@ -20,5 +21,14 @@ public class ProblemEventHandler {
     @Async
     public void changeRemovalDate(final SectorRemovalDateUpdatedEvent event) {
         problemsService.changeRemovalDate(event.getSectorId(), event.getRemovalDate());
+    }
+
+    @TransactionalEventListener(
+        classes = SectorRemovalDateUpdatedEvent.class,
+        phase = TransactionPhase.AFTER_COMMIT
+    )
+    @Async
+    public void expireProblem(final SectorExpiredEvent event) {
+        problemsService.expireProblems(event.getExpiredSectorsIds());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -1,0 +1,24 @@
+package com.first.flash.climbing.problem.application;
+
+import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemEventHandler {
+
+    private final ProblemsService problemsService;
+
+    @TransactionalEventListener(
+        classes = SectorRemovalDateUpdatedEvent.class,
+        phase = TransactionPhase.AFTER_COMMIT
+    )
+    @Async
+    public void changeRemovalDate(final SectorRemovalDateUpdatedEvent event) {
+        problemsService.changeRemovalDate(event.getSectorId(), event.getRemovalDate());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -1,6 +1,6 @@
 package com.first.flash.climbing.problem.application;
 
-import com.first.flash.climbing.sector.application.SectorExpiredEvent;
+import com.first.flash.climbing.sector.domain.SectorExpiredEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -24,7 +24,7 @@ public class ProblemEventHandler {
     }
 
     @TransactionalEventListener(
-        classes = SectorRemovalDateUpdatedEvent.class,
+        classes = SectorExpiredEvent.class,
         phase = TransactionPhase.AFTER_COMMIT
     )
     @Async

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -1,7 +1,9 @@
 package com.first.flash.climbing.problem.application;
 
+import com.first.flash.climbing.problem.domain.ProblemRepository;
 import com.first.flash.climbing.problem.domain.QueryProblemRepository;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,9 +14,16 @@ import org.springframework.transaction.annotation.Transactional;
 public class ProblemsService {
 
     private final QueryProblemRepository queryProblemRepository;
+    private final ProblemRepository problemRepository;
 
     @Transactional
     public void changeRemovalDate(final Long sectorId, final LocalDate removalDate) {
         queryProblemRepository.updateRemovalDateBySectorId(sectorId, removalDate);
+    }
+
+    @Transactional
+    public void expireProblems(final List<Long> expiredSectorsIds) {
+        queryProblemRepository.expireSectorsById(expiredSectorsIds);
+        problemRepository.expireSectorsById(expiredSectorsIds);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -1,0 +1,20 @@
+package com.first.flash.climbing.problem.application;
+
+import com.first.flash.climbing.problem.domain.QueryProblemRepository;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProblemsService {
+
+    private final QueryProblemRepository queryProblemRepository;
+
+    @Transactional
+    public void changeRemovalDate(final Long sectorId, final LocalDate removalDate) {
+        queryProblemRepository.updateRemovalDateBySectorId(sectorId, removalDate);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -23,7 +23,7 @@ public class ProblemsService {
 
     @Transactional
     public void expireProblems(final List<Long> expiredSectorsIds) {
-        queryProblemRepository.expireSectorsById(expiredSectorsIds);
-        problemRepository.expireSectorsById(expiredSectorsIds);
+        queryProblemRepository.expireProblemsBySectorIds(expiredSectorsIds);
+        problemRepository.expireProblemsBySectorIds(expiredSectorsIds);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
@@ -10,5 +10,5 @@ public interface ProblemRepository {
 
     Optional<Problem> findById(final UUID id);
 
-    void expireSectorsById(final List<Long> expiredSectorsIds);
+    void expireProblemsBySectorIds(final List<Long> expiredSectorsIds);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.problem.domain;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -8,4 +9,6 @@ public interface ProblemRepository {
     Problem save(final Problem problem);
 
     Optional<Problem> findById(final UUID id);
+
+    void expireSectorsById(final List<Long> expiredSectorsIds);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -18,4 +18,6 @@ public interface QueryProblemRepository {
         final Boolean hasSolution);
 
     void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate);
+
+    void expireSectorsById(final List<Long> expiredSectorsIds);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.problem.domain;
 
 import com.first.flash.climbing.problem.infrastructure.paging.Cursor;
 import com.first.flash.climbing.problem.infrastructure.paging.SortBy;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -15,4 +16,6 @@ public interface QueryProblemRepository {
     List<QueryProblem> findAll(final Cursor preCursor, final SortBy sortBy, final int size,
         final Long gymId, final List<String> difficulty, final List<String> sector,
         final Boolean hasSolution);
+
+    void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -19,5 +19,5 @@ public interface QueryProblemRepository {
 
     void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate);
 
-    void expireSectorsById(final List<Long> expiredSectorsIds);
+    void expireProblemsBySectorIds(final List<Long> expiredSectorsIds);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemQueryDslRepository.java
@@ -1,0 +1,22 @@
+package com.first.flash.climbing.problem.infrastructure;
+
+import static com.first.flash.climbing.problem.domain.QProblem.problem;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ProblemQueryDslRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    public void expireSectorsById(final List<Long> expiredSectorsIds) {
+        queryFactory.update(problem)
+                    .set(problem.isExpired, true)
+                    .where(problem.sectorId.in(expiredSectorsIds))
+                    .execute();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemQueryDslRepository.java
@@ -13,7 +13,7 @@ public class ProblemQueryDslRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public void expireSectorsById(final List<Long> expiredSectorsIds) {
+    public void expireProblemsBySectorIds(final List<Long> expiredSectorsIds) {
         queryFactory.update(problem)
                     .set(problem.isExpired, true)
                     .where(problem.sectorId.in(expiredSectorsIds))

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
@@ -26,7 +26,7 @@ public class ProblemRepositoryImpl implements ProblemRepository {
     }
 
     @Override
-    public void expireSectorsById(final List<Long> expiredSectorsIds) {
-        queryDslRepository.expireSectorsById(expiredSectorsIds);
+    public void expireProblemsBySectorIds(final List<Long> expiredSectorsIds) {
+        queryDslRepository.expireProblemsBySectorIds(expiredSectorsIds);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
@@ -2,7 +2,7 @@ package com.first.flash.climbing.problem.infrastructure;
 
 import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
-import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +23,10 @@ public class ProblemRepositoryImpl implements ProblemRepository {
     @Override
     public Optional<Problem> findById(final UUID id) {
         return jpaRepository.findById(id);
+    }
+
+    @Override
+    public void expireSectorsById(final List<Long> expiredSectorsIds) {
+        queryDslRepository.expireSectorsById(expiredSectorsIds);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.problem.infrastructure;
 
 import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Repository;
 public class ProblemRepositoryImpl implements ProblemRepository {
 
     private final ProblemJpaRepository jpaRepository;
+    private final ProblemQueryDslRepository queryDslRepository;
 
     @Override
     public Problem save(final Problem problem) {

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -42,6 +42,13 @@ public class QueryProblemQueryDslRepository {
                     .execute();
     }
 
+    public void expireSectorsById(final List<Long> expiredSectorsIds) {
+        queryFactory.update(queryProblem)
+                    .set(queryProblem.isExpired, true)
+                    .where(queryProblem.sectorId.in(expiredSectorsIds))
+                    .execute();
+    }
+
     private BooleanExpression inGym(final Long gymId) {
         return queryProblem.gymId.eq(gymId);
     }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -42,7 +42,7 @@ public class QueryProblemQueryDslRepository {
                     .execute();
     }
 
-    public void expireSectorsById(final List<Long> expiredSectorsIds) {
+    public void expireProblemsBySectorIds(final List<Long> expiredSectorsIds) {
         queryFactory.update(queryProblem)
                     .set(queryProblem.isExpired, true)
                     .where(queryProblem.sectorId.in(expiredSectorsIds))

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -10,6 +10,7 @@ import com.first.flash.climbing.problem.infrastructure.paging.SortBy;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
@@ -32,6 +33,13 @@ public class QueryProblemQueryDslRepository {
             .orderBy(sortItem(sortBy), queryProblem.id.desc())
             .limit(size)
             .fetch();
+    }
+
+    public void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate) {
+        queryFactory.update(queryProblem)
+                    .set(queryProblem.removalDate, removalDate)
+                    .where(queryProblem.sectorId.eq(sectorId))
+                    .execute();
     }
 
     private BooleanExpression inGym(final Long gymId) {

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -40,4 +40,9 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
     public void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate) {
         queryProblemQueryDslRepository.updateRemovalDateBySectorId(sectorId, removalDate);
     }
+
+    @Override
+    public void expireSectorsById(final List<Long> expiredSectorsIds) {
+        queryProblemQueryDslRepository.expireSectorsById(expiredSectorsIds);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -42,7 +42,7 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
     }
 
     @Override
-    public void expireSectorsById(final List<Long> expiredSectorsIds) {
-        queryProblemQueryDslRepository.expireSectorsById(expiredSectorsIds);
+    public void expireProblemsBySectorIds(final List<Long> expiredSectorsIds) {
+        queryProblemQueryDslRepository.expireProblemsBySectorIds(expiredSectorsIds);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.first.flash.climbing.problem.domain.QueryProblem;
 import com.first.flash.climbing.problem.domain.QueryProblemRepository;
 import com.first.flash.climbing.problem.infrastructure.paging.Cursor;
 import com.first.flash.climbing.problem.infrastructure.paging.SortBy;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -33,5 +34,10 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
         final Boolean hasSolution) {
         return queryProblemQueryDslRepository.findAll(prevCursor, sortBy, size,
             gymId, difficulty, sector, hasSolution);
+    }
+
+    @Override
+    public void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate) {
+        queryProblemQueryDslRepository.updateRemovalDateBySectorId(sectorId, removalDate);
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorExpireScheduler.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorExpireScheduler.java
@@ -1,0 +1,17 @@
+package com.first.flash.climbing.sector.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SectorExpireScheduler {
+
+    private final SectorService sectorService;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void expireSector() {
+        sectorService.expireSector();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorExpiredEvent.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorExpiredEvent.java
@@ -1,0 +1,17 @@
+package com.first.flash.climbing.sector.application;
+
+import com.first.flash.global.event.Event;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SectorExpiredEvent extends Event {
+
+    private List<Long> expiredSectorsIds;
+
+    public static SectorExpiredEvent of(final List<Long> expiredSectorIds) {
+        return new SectorExpiredEvent(expiredSectorIds);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
@@ -4,6 +4,7 @@ import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorWriteDetailResponseDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRemovalDateRequestDto;
 import com.first.flash.climbing.sector.domain.Sector;
+import com.first.flash.climbing.sector.domain.SectorExpiredEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorRepository;
 import com.first.flash.climbing.sector.exception.exceptions.SectorNotFoundException;

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
@@ -9,6 +9,7 @@ import com.first.flash.climbing.sector.domain.SectorRepository;
 import com.first.flash.climbing.sector.exception.exceptions.SectorNotFoundException;
 import com.first.flash.global.event.Events;
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,12 @@ public class SectorService {
         sector.updateRemovalDate(removalDate);
         Events.raise(SectorRemovalDateUpdatedEvent.of(sectorId, removalDate));
         return SectorWriteDetailResponseDto.toDto(sector);
+    }
+
+    @Transactional
+    public void expireSector() {
+        List<Long> expiredSectorIds = sectorRepository.updateExpiredSector();
+        Events.raise(SectorExpiredEvent.of(expiredSectorIds));
     }
 
     public Sector findById(final Long id) {

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
@@ -4,8 +4,11 @@ import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorWriteDetailResponseDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRemovalDateRequestDto;
 import com.first.flash.climbing.sector.domain.Sector;
+import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorRepository;
 import com.first.flash.climbing.sector.exception.exceptions.SectorNotFoundException;
+import com.first.flash.global.event.Events;
+import java.time.LocalDate;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,7 +32,9 @@ public class SectorService {
     public SectorWriteDetailResponseDto updateSectorRemovalDate(final Long sectorId,
         final SectorUpdateRemovalDateRequestDto sectorUpdateRemovalDateRequestDto) {
         Sector sector = findById(sectorId);
-        sector.updateRemovalDate(sectorUpdateRemovalDateRequestDto.removalDate());
+        LocalDate removalDate = sectorUpdateRemovalDateRequestDto.removalDate();
+        sector.updateRemovalDate(removalDate);
+        Events.raise(SectorRemovalDateUpdatedEvent.of(sectorId, removalDate));
         return SectorWriteDetailResponseDto.toDto(sector);
     }
 

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorExpiredEvent.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorExpiredEvent.java
@@ -1,4 +1,4 @@
-package com.first.flash.climbing.sector.application;
+package com.first.flash.climbing.sector.domain;
 
 import com.first.flash.global.event.Event;
 import java.util.List;

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorRemovalDateUpdatedEvent.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorRemovalDateUpdatedEvent.java
@@ -1,0 +1,19 @@
+package com.first.flash.climbing.sector.domain;
+
+import com.first.flash.global.event.Event;
+import java.time.LocalDate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SectorRemovalDateUpdatedEvent extends Event {
+
+    private Long sectorId;
+    private LocalDate removalDate;
+
+    public static SectorRemovalDateUpdatedEvent of(
+        final Long sectorId, final LocalDate removalDate) {
+        return new SectorRemovalDateUpdatedEvent(sectorId, removalDate);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorRepository.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorRepository.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.sector.domain;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface SectorRepository {
@@ -7,4 +8,6 @@ public interface SectorRepository {
     Sector save(final Sector sector);
 
     Optional<Sector> findById(final Long id);
+
+    List<Long> updateExpiredSector();
 }

--- a/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorQueryDslRepository.java
@@ -1,0 +1,39 @@
+package com.first.flash.climbing.sector.infrastructure;
+
+import static com.first.flash.climbing.sector.domain.QSector.sector;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SectorQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Long> updateExpiredSector() {
+        List<Long> expiredSectorIds = findExpiredSectorIds();
+        jpaQueryFactory.update(sector)
+                       .set(sector.removalInfo.isExpired, true)
+                       .where(sector.id.in(expiredSectorIds))
+                       .execute();
+        return expiredSectorIds;
+    }
+
+    private List<Long> findExpiredSectorIds() {
+        return jpaQueryFactory.select(sector.id)
+                              .where(isExpired())
+                              .fetch();
+    }
+
+    private static BooleanExpression isExpired() {
+        return sector.removalInfo.isExpired.isFalse()
+                                           .and(
+                                               sector.removalInfo.removalDate
+                                                   .before(LocalDate.now()));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.sector.infrastructure;
 
 import com.first.flash.climbing.sector.domain.Sector;
 import com.first.flash.climbing.sector.domain.SectorRepository;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class SectorRepositoryImpl implements SectorRepository {
 
     private final SectorJpaRepository sectorJpaRepository;
+    private final SectorQueryDslRepository sectorQueryDslRepository;
 
     @Override
     public Sector save(final Sector sector) {
@@ -20,5 +22,10 @@ public class SectorRepositoryImpl implements SectorRepository {
     @Override
     public Optional<Sector> findById(final Long id) {
         return sectorJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Long> updateExpiredSector() {
+        return sectorQueryDslRepository.updateExpiredSector();
     }
 }

--- a/src/main/java/com/first/flash/global/config/EventConfig.java
+++ b/src/main/java/com/first/flash/global/config/EventConfig.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @RequiredArgsConstructor
-public class EventConfiguration {
+public class EventConfig {
 
     private final ApplicationContext applicationContext;
 

--- a/src/main/java/com/first/flash/global/config/EventConfiguration.java
+++ b/src/main/java/com/first/flash/global/config/EventConfiguration.java
@@ -1,0 +1,20 @@
+package com.first.flash.global.config;
+
+import com.first.flash.global.event.Events;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class EventConfiguration {
+
+    private final ApplicationContext applicationContext;
+
+    @Bean
+    public InitializingBean eventsInitializer() {
+        return () -> Events.setPublisher(applicationContext);
+    }
+}

--- a/src/main/java/com/first/flash/global/config/SchedulerConfig.java
+++ b/src/main/java/com/first/flash/global/config/SchedulerConfig.java
@@ -1,0 +1,32 @@
+package com.first.flash.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+
+@Configuration
+public class SchedulerConfig {
+
+    @Value("${scheduler.pool.size}")
+    private int poolSize;
+
+    @Value("${scheduler.threadNamePrefix}")
+    private String threadNamePrefix;
+
+    @Value("${scheduler.awaitTerminationSeconds}")
+    private int awaitTerminationSeconds;
+
+    @Value("${scheduler.waitForTasksToCompleteOnShutdown}")
+    private boolean waitForTasksToCompleteOnShutdown;
+
+    @Bean
+    public ThreadPoolTaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+        scheduler.setPoolSize(poolSize);
+        scheduler.setThreadNamePrefix(threadNamePrefix);
+        scheduler.setAwaitTerminationSeconds(awaitTerminationSeconds);
+        scheduler.setWaitForTasksToCompleteOnShutdown(waitForTasksToCompleteOnShutdown);
+        return scheduler;
+    }
+}

--- a/src/main/java/com/first/flash/global/config/SwaggerConfig.java
+++ b/src/main/java/com/first/flash/global/config/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.first.flash.climbing;
+package com.first.flash.global.config;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;

--- a/src/main/java/com/first/flash/global/event/Event.java
+++ b/src/main/java/com/first/flash/global/event/Event.java
@@ -1,0 +1,13 @@
+package com.first.flash.global.event;
+
+import lombok.Getter;
+
+@Getter
+public abstract class Event {
+
+    private long timestamp;
+
+    public Event() {
+        this.timestamp = System.currentTimeMillis();
+    }
+}

--- a/src/main/java/com/first/flash/global/event/Events.java
+++ b/src/main/java/com/first/flash/global/event/Events.java
@@ -1,0 +1,18 @@
+package com.first.flash.global.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+
+public class Events {
+
+    private static ApplicationEventPublisher publisher;
+
+    public static void setPublisher(final ApplicationEventPublisher publisher) {
+        Events.publisher = publisher;
+    }
+
+    public static void raise(final Object event) {
+        if (publisher != null) {
+            publisher.publishEvent(event);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,4 +19,10 @@ springdoc.swagger-ui.deepLinking=true
 spring.task.execution.pool.core-size=10
 spring.task.execution.pool.max-size=50
 spring.task.execution.pool.queue-capacity=100
-spring.task.execution.pool.keep-alive=60s
+spring.task.execution.pool.keep-alive=60
+spring.task.execution.thread-name-prefix=TaskExecutor-
+# Scheduler Task settings
+scheduler.pool.size=5
+scheduler.threadNamePrefix=Scheduler-
+scheduler.awaitTerminationSeconds=30
+scheduler.waitForTasksToCompleteOnShutdown=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,5 @@
 server.port=8080
 spring.application.name=flash
-
 spring.datasource.url=${DB_URL}
 spring.datasource.driverClassName=${DB_DRIVER_CLASS}
 spring.datasource.username=${DB_USERNAME}
@@ -8,7 +7,6 @@ spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=${DB_DDL_AUTO}
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
-
 # Swagger
 springdoc.api-docs.path=/v1/api-docs
 springdoc.swagger-ui.path=/swagger-ui.html
@@ -17,3 +15,8 @@ springdoc.swagger-ui.defaultModelExpandDepth=1
 springdoc.swagger-ui.display-request-duration=true
 springdoc.swagger-ui.tryItOutEnabled=true
 springdoc.swagger-ui.deepLinking=true
+# Task Executor
+spring.task.execution.pool.core-size=10
+spring.task.execution.pool.max-size=50
+spring.task.execution.pool.queue-capacity=100
+spring.task.execution.pool.keep-alive=60s

--- a/src/test/java/com/first/flash/climbing/sector/infrastructure/FakeSectorRepository.java
+++ b/src/test/java/com/first/flash/climbing/sector/infrastructure/FakeSectorRepository.java
@@ -3,6 +3,7 @@ package com.first.flash.climbing.sector.infrastructure;
 import com.first.flash.climbing.sector.domain.Sector;
 import com.first.flash.climbing.sector.domain.SectorRepository;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -21,5 +22,15 @@ public class FakeSectorRepository implements SectorRepository {
     @Override
     public Optional<Sector> findById(final Long id) {
         return Optional.ofNullable(db.get(id));
+    }
+
+    @Override
+    public List<Long> updateExpiredSector() {
+        List<Long> expiredIds = db.keySet().stream()
+                            .filter(key -> db.get(key).getRemovalInfo().getRemovalDate()
+                                             .isBefore(db.get(key).getSettingDate()))
+                            .toList();
+        expiredIds.forEach(db::remove);
+        return expiredIds;
     }
 }


### PR DESCRIPTION
# 작업 내용
- 섹터 만료 스케줄러
- 이벤트 처리
- 서버 시간 설정

## 스케줄러
매일 자정마다 탈거일이 지난 섹터를 만료시킨다.
이때 섹터 만료 요청은 멱등성이 보장되므로, 분산 환경에 대한 처리는 따로 하지 않는다.

## 이벤트 처리
### 섹터 탈거일 변경 이벤트
섹터의 탈거일이 변경되면, 반정규화된 문제 조회 모델의 탈거일 또한 변경되어야 한다.

### 섹터 만료 이벤트
스케줄러를 통해 탈거일이 지난 섹터를 만료시키고, 만료된 섹터의 문제 또한 이벤트를 이용해 만료시킨다.