### PR TITLE
이벤트 동기화

### DIFF
--- a/src/main/java/com/first/flash/FlashApplication.java
+++ b/src/main/java/com/first/flash/FlashApplication.java
@@ -4,11 +4,9 @@ import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableAsync
 @EnableScheduling
 public class FlashApplication {
 

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -4,10 +4,9 @@ import com.first.flash.climbing.sector.domain.SectorExpiredEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
 import com.first.flash.climbing.solution.domain.SolutionSavedEvent;
 import lombok.RequiredArgsConstructor;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -15,29 +14,20 @@ public class ProblemEventHandler {
 
     private final ProblemsService problemsService;
 
-    @TransactionalEventListener(
-        classes = SectorRemovalDateUpdatedEvent.class,
-        phase = TransactionPhase.AFTER_COMMIT
-    )
-    @Async
+    @EventListener
+    @Transactional
     public void changeRemovalDate(final SectorRemovalDateUpdatedEvent event) {
         problemsService.changeRemovalDate(event.getSectorId(), event.getRemovalDate());
     }
 
-    @TransactionalEventListener(
-        classes = SectorExpiredEvent.class,
-        phase = TransactionPhase.AFTER_COMMIT
-    )
-    @Async
+    @EventListener
+    @Transactional
     public void expireProblem(final SectorExpiredEvent event) {
         problemsService.expireProblems(event.getExpiredSectorsIds());
     }
 
-    @TransactionalEventListener(
-        classes = SolutionSavedEvent.class,
-        phase = TransactionPhase.AFTER_COMMIT
-    )
-    @Async
+    @EventListener
+    @Transactional
     public void updateProblemSolutionInfo(final SolutionSavedEvent event) {
         problemsService.updateProblemSolutionInfo(event.getProblemId());
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,12 +15,6 @@ springdoc.swagger-ui.defaultModelExpandDepth=1
 springdoc.swagger-ui.display-request-duration=true
 springdoc.swagger-ui.tryItOutEnabled=true
 springdoc.swagger-ui.deepLinking=true
-# Task Executor
-spring.task.execution.pool.core-size=10
-spring.task.execution.pool.max-size=50
-spring.task.execution.pool.queue-capacity=100
-spring.task.execution.pool.keep-alive=60
-spring.task.execution.thread-name-prefix=TaskExecutor-
 # Scheduler Task settings
 scheduler.pool.size=5
 scheduler.threadNamePrefix=Scheduler-


### PR DESCRIPTION
현재 이벤트를 사용하는 로직은 다음과 같습니다.
1. 섹터 만료에 따른 문제 만료
2. 섹터 탈거일 변경에 따른 문제 탈거일 변경
3. 해설 영상 등록에 따른 문제 조회 모델 조회수 증가, 해설 영상 여부 상태 변경, 추천값 갱신

위 이벤트는 각 애그리거트의 결합을 느슨하게 하기 위함일 뿐, 비동기일 필요가 없기 때문에 한 트랜잭션 내에서 수행되도록 수정했습니다.