### PR TITLE
에러 메시지 형식 수정

### DIFF
--- a/src/main/java/com/first/flash/climbing/gym/exception/ClimbingGymExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/gym/exception/ClimbingGymExceptionHandler.java
@@ -5,6 +5,7 @@ import com.first.flash.climbing.gym.exception.exceptions.DifficultyNotFoundExcep
 import com.first.flash.climbing.gym.exception.exceptions.DuplicateDifficultyLevelException;
 import com.first.flash.climbing.gym.exception.exceptions.DuplicateDifficultyNameException;
 import com.first.flash.climbing.gym.exception.exceptions.NoSectorGymException;
+import com.first.flash.global.dto.ErrorResponseDto;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.http.HttpStatus;
@@ -18,19 +19,19 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class ClimbingGymExceptionHandler {
 
     @ExceptionHandler(ClimbingGymNotFoundException.class)
-    public ResponseEntity<String> handleClimbingGymNotFoundException(
+    public ResponseEntity<ErrorResponseDto> handleClimbingGymNotFoundException(
         final ClimbingGymNotFoundException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
     @ExceptionHandler(DifficultyNotFoundException.class)
-    public ResponseEntity<String> handleDifficultyNotFoundException(
+    public ResponseEntity<ErrorResponseDto> handleDifficultyNotFoundException(
         final DifficultyNotFoundException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
     @ExceptionHandler(NoSectorGymException.class)
-    public ResponseEntity<String> handleNoSectorGymException(
+    public ResponseEntity<ErrorResponseDto> handleNoSectorGymException(
         final NoSectorGymException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
@@ -50,20 +51,21 @@ public class ClimbingGymExceptionHandler {
     }
 
     @ExceptionHandler(DuplicateDifficultyLevelException.class)
-    public ResponseEntity<String> handleDuplicateDifficultyLevelException(
+    public ResponseEntity<ErrorResponseDto> handleDuplicateDifficultyLevelException(
         final DuplicateDifficultyLevelException exception) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }
 
     @ExceptionHandler(DuplicateDifficultyNameException.class)
-    public ResponseEntity<String> handleDuplicateDifficultyNameException(
+    public ResponseEntity<ErrorResponseDto> handleDuplicateDifficultyNameException(
         final DuplicateDifficultyNameException exception) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }
 
-    private ResponseEntity<String> getResponseWithStatus(final HttpStatus httpStatus,
+    private ResponseEntity<ErrorResponseDto> getResponseWithStatus(final HttpStatus httpStatus,
         final RuntimeException exception) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
         return ResponseEntity.status(httpStatus)
-                             .body(exception.getMessage());
+                             .body(errorResponse);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/exception/ProblemExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/exception/ProblemExceptionHandler.java
@@ -4,6 +4,7 @@ import com.first.flash.climbing.problem.exception.exceptions.InvalidCursorExcept
 import com.first.flash.climbing.problem.exception.exceptions.ProblemNotFoundException;
 import com.first.flash.climbing.problem.exception.exceptions.QueryProblemExpiredException;
 import com.first.flash.climbing.problem.exception.exceptions.QueryProblemNotFoundException;
+import com.first.flash.global.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -13,32 +14,33 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class ProblemExceptionHandler {
 
     @ExceptionHandler
-    public ResponseEntity<String> handleProblemExpiredException(
+    public ResponseEntity<ErrorResponseDto> handleProblemExpiredException(
         final QueryProblemExpiredException exception) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }
 
     @ExceptionHandler
-    public ResponseEntity<String> handleQueryProblemNotFoundException(
+    public ResponseEntity<ErrorResponseDto> handleQueryProblemNotFoundException(
         final QueryProblemNotFoundException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
     @ExceptionHandler
-    public ResponseEntity<String> handleProblemNotFoundException(
+    public ResponseEntity<ErrorResponseDto> handleProblemNotFoundException(
         final ProblemNotFoundException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
     @ExceptionHandler
-    public ResponseEntity<String> handleInvalidCursorException(
+    public ResponseEntity<ErrorResponseDto> handleInvalidCursorException(
         final InvalidCursorException exception) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }
 
-    private ResponseEntity<String> getResponseWithStatus(final HttpStatus httpStatus,
+    private ResponseEntity<ErrorResponseDto> getResponseWithStatus(final HttpStatus httpStatus,
         final RuntimeException exception) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
         return ResponseEntity.status(httpStatus)
-                             .body(exception.getMessage());
+                             .body(errorResponse);
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/exception/SectorExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/sector/exception/SectorExceptionHandler.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.sector.exception;
 
 import com.first.flash.climbing.sector.exception.exceptions.InvalidRemovalDateException;
 import com.first.flash.climbing.sector.exception.exceptions.SectorNotFoundException;
+import com.first.flash.global.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -11,20 +12,21 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class SectorExceptionHandler {
 
     @ExceptionHandler(SectorNotFoundException.class)
-    public ResponseEntity<String> handleSectorNotFoundException(
+    public ResponseEntity<ErrorResponseDto> handleSectorNotFoundException(
         final SectorNotFoundException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
     @ExceptionHandler(InvalidRemovalDateException.class)
-    public ResponseEntity<String> handleInvalidRemovalDateException(
+    public ResponseEntity<ErrorResponseDto> handleInvalidRemovalDateException(
         final InvalidRemovalDateException exception) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }
 
-    private ResponseEntity<String> getResponseWithStatus(final HttpStatus httpStatus,
+    private ResponseEntity<ErrorResponseDto> getResponseWithStatus(final HttpStatus httpStatus,
         final RuntimeException exception) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
         return ResponseEntity.status(httpStatus)
-                             .body(exception.getMessage());
+                             .body(errorResponse);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.solution.exception;
 
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
+import com.first.flash.global.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -10,9 +11,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 public class SolutionExceptionHandler {
 
     @ExceptionHandler(SolutionNotFoundException.class)
-    public ResponseEntity<String> handleSolutionNotFoundException(
+    public ResponseEntity<ErrorResponseDto> handleSolutionNotFoundException(
         final SolutionNotFoundException exception) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
-            .body(exception.getMessage());
+                             .body(errorResponse);
     }
 }

--- a/src/main/java/com/first/flash/global/dto/ErrorResponseDto.java
+++ b/src/main/java/com/first/flash/global/dto/ErrorResponseDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.global.dto;
+
+public record ErrorResponseDto(String message) {
+
+}


### PR DESCRIPTION
# 요약

에러 메시지의 형식을 정의하고 코드에 반영

# 내용

## 에러 메시지 형식 정의

### 기존 에러 메시지 형식

```json
"이미지 URL은 필수입니다."
```

- 정의한 형식이 없어 임시로 에러 문자열을 그대로 반환

### 새로 정의한 에러 메시지 형식

```json
{
  "message": "이미지 URL은 필수입니다."
}
```

- 에러 종류에 따른 행동 분리가 필요 없을 것이라고 판단하였음
- 가장 비용이 적게 드는 형식을 선택함

### 참고 자료

- [형식 정의 과정](https://sandy-wedelia-038.notion.site/54c84e7ee8f54b2a8216e453572c10ed?pvs=4)

## ErrorResponseDto

```java
package com.first.flash.global.dto;

public record ErrorResponseDto(String message) {

}
```

- global 패키지에 에러 메시지 형식을 dto로 정의

# 참고 이미지

<img width="500" alt="image" src="https://github.com/user-attachments/assets/8c885cdc-c271-48ed-a4c0-e2ee77359381">
