### PR TITLE
인증/인가, 회원 관련 도메인 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    // jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/first/flash/account/auth/domain/TokenManager.java
+++ b/src/main/java/com/first/flash/account/auth/domain/TokenManager.java
@@ -1,0 +1,10 @@
+package com.first.flash.account.auth.domain;
+
+import java.util.UUID;
+
+public interface TokenManager {
+
+    String createAccessToken(final UUID id);
+    boolean validateToken(final String token);
+    UUID parseToken(final String token);
+}

--- a/src/main/java/com/first/flash/account/auth/exception/exceptions/InvalidTokenException.java
+++ b/src/main/java/com/first/flash/account/auth/exception/exceptions/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package com.first.flash.account.auth.exception.exceptions;
+
+public class InvalidTokenException extends RuntimeException {
+
+    public InvalidTokenException() {
+        super("유효하지 않은 토큰입니다!");
+    }
+}

--- a/src/main/java/com/first/flash/account/auth/exception/exceptions/TokenExpiredException.java
+++ b/src/main/java/com/first/flash/account/auth/exception/exceptions/TokenExpiredException.java
@@ -1,0 +1,8 @@
+package com.first.flash.account.auth.exception.exceptions;
+
+public class TokenExpiredException extends RuntimeException {
+
+    public TokenExpiredException() {
+        super("만료된 토큰입니다!");
+    }
+}

--- a/src/main/java/com/first/flash/account/auth/infrastructure/JwtManager.java
+++ b/src/main/java/com/first/flash/account/auth/infrastructure/JwtManager.java
@@ -1,0 +1,82 @@
+package com.first.flash.account.auth.infrastructure;
+
+import com.first.flash.account.auth.domain.TokenManager;
+import com.first.flash.account.auth.exception.exceptions.InvalidTokenException;
+import com.first.flash.account.auth.exception.exceptions.TokenExpiredException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.Jwts.SIG;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import java.util.Date;
+import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class JwtManager implements TokenManager {
+
+    @Value("${auth.jwt.secret}")
+    private String secretKey;
+    @Value("${auth.jwt.expiration}")
+    private Long expiredSecond;
+    private SecretKey key;
+
+    @PostConstruct
+    private void init() {
+        key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    @Override
+    public String createAccessToken(final UUID id) {
+        Claims claim = Jwts.claims()
+                           .subject(id.toString())
+                           .build();
+        Date now = new Date();
+        Date expiredIn = new Date(now.getTime() + expiredSecond);
+
+        return Jwts.builder()
+                   .claims(claim)
+                   .issuedAt(now)
+                   .expiration(expiredIn)
+                   .signWith(key, SIG.HS512)
+                   .compact();
+    }
+
+    @Override
+    public boolean validateToken(final String token) {
+        if (!StringUtils.hasText(token)) {
+            return false;
+        }
+
+        Claims claims = parseClaims(token);
+        return claims.getExpiration()
+                     .after(new Date());
+    }
+
+    @Override
+    public UUID parseToken(final String token) {
+        Claims claims = parseClaims(token);
+        return UUID.fromString(claims.getSubject());
+    }
+
+    private Claims parseClaims(final String token) {
+        try {
+            return Jwts.parser()
+                       .verifyWith(key)
+                       .build()
+                       .parseSignedClaims(token)
+                       .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new TokenExpiredException();
+        } catch (MalformedJwtException e) {
+            throw new InvalidTokenException();
+        } catch (SecurityException e) {
+            throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/com/first/flash/account/member/domain/Gender.java
+++ b/src/main/java/com/first/flash/account/member/domain/Gender.java
@@ -1,0 +1,11 @@
+package com.first.flash.account.member.domain;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Gender {
+
+    MALE("male"), FEMALE("female");
+
+    private String gender;
+}

--- a/src/main/java/com/first/flash/account/member/domain/Member.java
+++ b/src/main/java/com/first/flash/account/member/domain/Member.java
@@ -1,0 +1,48 @@
+package com.first.flash.account.member.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Member {
+
+    @Id
+    private UUID id;
+    private String email;
+    private String nickName;
+    private String instagramId;
+    private Double height;
+    private Double reach;
+    private String profileImageUrl;
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    public static Member of(final UUID id, final String email, final String nickName,
+        final String instagramId, final Double height, final Double reach,
+        final String profileImageUrl, final Gender gender) {
+        return Member.builder()
+                     .id(id)
+                     .email(email)
+                     .nickName(nickName)
+                     .instagramId(instagramId)
+                     .height(height)
+                     .reach(reach)
+                     .profileImageUrl(profileImageUrl)
+                     .gender(gender)
+                     .role(Role.ROLE_USER)
+                     .build();
+    }
+}

--- a/src/main/java/com/first/flash/account/member/domain/MemberRepository.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberRepository.java
@@ -1,0 +1,5 @@
+package com.first.flash.account.member.domain;
+
+public interface MemberRepository {
+
+}

--- a/src/main/java/com/first/flash/account/member/domain/Role.java
+++ b/src/main/java/com/first/flash/account/member/domain/Role.java
@@ -1,0 +1,10 @@
+package com.first.flash.account.member.domain;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum Role {
+
+    ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER");
+    private String role;
+}

--- a/src/main/java/com/first/flash/account/member/domain/Role.java
+++ b/src/main/java/com/first/flash/account/member/domain/Role.java
@@ -6,5 +6,6 @@ import lombok.AllArgsConstructor;
 public enum Role {
 
     ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER");
+
     private String role;
 }

--- a/src/main/java/com/first/flash/account/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/com/first/flash/account/member/infrastructure/MemberJpaRepository.java
@@ -1,0 +1,9 @@
+package com.first.flash.account.member.infrastructure;
+
+import com.first.flash.account.member.domain.Member;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberJpaRepository extends JpaRepository<Member, UUID> {
+
+}

--- a/src/main/java/com/first/flash/account/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/com/first/flash/account/member/infrastructure/MemberRepositoryImpl.java
@@ -1,0 +1,11 @@
+package com.first.flash.account.member.infrastructure;
+
+import com.first.flash.account.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberRepositoryImpl implements MemberRepository {
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ scheduler.pool.size=5
 scheduler.threadNamePrefix=Scheduler-
 scheduler.awaitTerminationSeconds=30
 scheduler.waitForTasksToCompleteOnShutdown=true
+# JWT
+auth.jwt.secret=${JWT_SECRET}
+auth.jwt.expiration=${JWT_EXPIRATION}

--- a/src/test/java/com/first/flash/account/auth/infrastructure/JwtManagerTest.java
+++ b/src/test/java/com/first/flash/account/auth/infrastructure/JwtManagerTest.java
@@ -1,0 +1,69 @@
+package com.first.flash.account.auth.infrastructure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.first.flash.account.auth.domain.TokenManager;
+import com.first.flash.account.auth.exception.exceptions.TokenExpiredException;
+import io.jsonwebtoken.security.Keys;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JwtManagerTest {
+
+    private TokenManager tokenManager;
+
+    @BeforeEach
+    void init() {
+        tokenManager = new JwtManager();
+        String testSecretKey = "dS5kuWLwxI8xnL/29JorFY1OM/ku4e7tOC+ryBs1WFx3bcZRHBgzWTMIklrx0b4GIljq+28fVZKQ+clx";
+        ReflectionTestUtils.setField(tokenManager, "secretKey", testSecretKey);
+        ReflectionTestUtils.setField(tokenManager, "expiredSecond", 1800000L);
+        ReflectionTestUtils.setField(tokenManager, "key",
+            Keys.hmacShaKeyFor(testSecretKey.getBytes()));
+    }
+
+    @Test
+    void 토큰_생성_파싱() {
+        // given
+        UUID id = UUID.randomUUID();
+        String accessToken = tokenManager.createAccessToken(id);
+
+        // when
+        boolean isValid = tokenManager.validateToken(accessToken);
+        UUID parsedId = tokenManager.parseToken(accessToken);
+
+        // then
+        assertThat(parsedId).isEqualTo(id);
+    }
+
+    @Test
+    void 토큰_검증() {
+        // given
+        UUID id = UUID.randomUUID();
+        String accessToken = tokenManager.createAccessToken(id);
+
+        // when
+        boolean isValid = tokenManager.validateToken(accessToken);
+
+        // then
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    void 토큰_만료_예외() {
+        // given
+        ReflectionTestUtils.setField(tokenManager, "expiredSecond", -1L);
+        UUID id = UUID.randomUUID();
+        String accessToken = tokenManager.createAccessToken(id);
+
+        // when & then
+        assertThatThrownBy(() -> tokenManager.parseToken(accessToken))
+            .isInstanceOf(TokenExpiredException.class);
+    }
+}


### PR DESCRIPTION
## TokenManager

### 역할
토큰을 생성, 검증, 추출 매니저 객체

**createAccessToken**
Member의 ID로 토큰을 생성

**validateToken**
token이 유효한지 검증

**parseToken**
token으로부터 유저의 id를 추출

### 기능 디테일
- JWT를 이용한 액세스 토큰 우선 구현
- 토큰을 생성할 때 유저의 id를 subject로, 토큰 만료 시간을 포함
- 토큰 만료 시간과 token을 생성할 때 사용할 비밀 키는 환경 변수 처리
---
## Member
회원 도메인

피그마에 기재된 속성
- nickName
- instagramId
- height
- reach
- profileImageUrl
- gender

인증/인가 과정에서 필요한 속성
- id
- email
- role