### PR TITLE
유저 차단 API 구현

### DIFF
--- a/src/main/java/com/first/flash/FlashApplication.java
+++ b/src/main/java/com/first/flash/FlashApplication.java
@@ -4,10 +4,12 @@ import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling
+@EnableJpaAuditing
 public class FlashApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/first/flash/account/member/application/BlockService.java
+++ b/src/main/java/com/first/flash/account/member/application/BlockService.java
@@ -1,0 +1,31 @@
+package com.first.flash.account.member.application;
+
+import com.first.flash.account.member.application.dto.MemberBlockResponse;
+import com.first.flash.account.member.domain.Member;
+import com.first.flash.account.member.domain.MemberBlock;
+import com.first.flash.account.member.infrastructure.BlockRepository;
+import com.first.flash.global.util.AuthUtil;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlockService {
+
+    private final BlockRepository blockRepository;
+    private final MemberService memberService;
+
+    @Transactional
+    public MemberBlockResponse blockMember(final UUID blockedUser) {
+        UUID blockerId = AuthUtil.getId();
+        Member blocker = memberService.findById(blockerId);
+        Member blocked = memberService.findById(blockedUser);
+        MemberBlock.blockMember(blocker, blocked);
+        MemberBlock blockResult = blockRepository.save(MemberBlock.blockMember(blocker, blocked));
+        blockRepository.save(blockResult);
+        return MemberBlockResponse.toDto(blocked);
+    }
+}

--- a/src/main/java/com/first/flash/account/member/application/dto/MemberBlockResponse.java
+++ b/src/main/java/com/first/flash/account/member/application/dto/MemberBlockResponse.java
@@ -1,0 +1,11 @@
+package com.first.flash.account.member.application.dto;
+
+import com.first.flash.account.member.domain.Member;
+import java.util.UUID;
+
+public record MemberBlockResponse(UUID blockedMemberId, String blockedMemberName) {
+
+    public static MemberBlockResponse toDto(final Member blockedMember) {
+        return new MemberBlockResponse(blockedMember.getId(), blockedMember.getNickName());
+    }
+}

--- a/src/main/java/com/first/flash/account/member/domain/MemberBlock.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberBlock.java
@@ -1,0 +1,40 @@
+package com.first.flash.account.member.domain;
+
+import com.first.flash.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MemberBlock extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "blockerId")
+    private Member blocker;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "blockedId")
+    private Member blocked;
+
+    private MemberBlock(final Member blocker, final Member blocked) {
+        this.blocker = blocker;
+        this.blocked = blocked;
+    }
+
+    public static MemberBlock blockMember(final Member blocker, final Member blocked) {
+        return new MemberBlock(blocker, blocked);
+    }
+}

--- a/src/main/java/com/first/flash/account/member/infrastructure/BlockRepository.java
+++ b/src/main/java/com/first/flash/account/member/infrastructure/BlockRepository.java
@@ -1,0 +1,11 @@
+package com.first.flash.account.member.infrastructure;
+
+import com.first.flash.account.member.domain.MemberBlock;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlockRepository extends JpaRepository<MemberBlock, Long> {
+
+    MemberBlock save(final MemberBlock memberBlock);
+}

--- a/src/main/java/com/first/flash/account/member/ui/MemberController.java
+++ b/src/main/java/com/first/flash/account/member/ui/MemberController.java
@@ -88,6 +88,15 @@ public class MemberController {
         return ResponseEntity.ok(memberService.confirmNickName(request));
     }
 
+    @Operation(summary = "유저 차단", description = "특정 유저 차단")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "차단 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberBlockResponse.class))),
+        @ApiResponse(responseCode = "404", description = "리소스를 찾을 수 없음",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "차단하려는 유저를 찾을 수 없음", value = "{\"error\": \"사용자를 찾을 수 없습니다!\"}"),
+            }))
+    })
     @PostMapping("/blocks/{blockedUserId}")
     public ResponseEntity<MemberBlockResponse> blockMember(@PathVariable final UUID blockedUserId) {
         return ResponseEntity.ok(blockService.blockMember(blockedUserId));

--- a/src/main/java/com/first/flash/account/member/ui/MemberController.java
+++ b/src/main/java/com/first/flash/account/member/ui/MemberController.java
@@ -1,8 +1,10 @@
 package com.first.flash.account.member.ui;
 
+import com.first.flash.account.member.application.BlockService;
 import com.first.flash.account.member.application.MemberService;
 import com.first.flash.account.member.application.dto.ConfirmNickNameRequest;
 import com.first.flash.account.member.application.dto.ConfirmNickNameResponse;
+import com.first.flash.account.member.application.dto.MemberBlockResponse;
 import com.first.flash.account.member.application.dto.MemberCompleteRegistrationRequest;
 import com.first.flash.account.member.application.dto.MemberCompleteRegistrationResponse;
 import com.first.flash.account.member.application.dto.MemberInfoResponse;
@@ -14,10 +16,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -29,6 +34,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
     private final MemberService memberService;
+    private final BlockService blockService;
 
     @Operation(summary = "내 정보 조회", description = "특정 회원 정보 조회")
     @ApiResponses(value = {
@@ -80,5 +86,10 @@ public class MemberController {
     public ResponseEntity<ConfirmNickNameResponse> confirmNickName(
         @Valid @RequestBody final ConfirmNickNameRequest request) {
         return ResponseEntity.ok(memberService.confirmNickName(request));
+    }
+
+    @PostMapping("/blocks/{blockedUserId}")
+    public ResponseEntity<MemberBlockResponse> blockMember(@PathVariable final UUID blockedUserId) {
+        return ResponseEntity.ok(blockService.blockMember(blockedUserId));
     }
 }

--- a/src/main/java/com/first/flash/global/domain/BaseEntity.java
+++ b/src/main/java/com/first/flash/global/domain/BaseEntity.java
@@ -1,0 +1,28 @@
+package com.first.flash.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}


### PR DESCRIPTION
## 작업 내용
![image](https://github.com/user-attachments/assets/50c680a7-5562-4d4f-b4c7-c85ea0d8daea)

### MemberBlock 엔티티 생성
차단 정보를 저장하는 MemberBlock 엔티티를 생성했습니다!
해당 정보는 차단한 유저, 차단 당한 유저 모두와  N:1 관계를 맺고 있습니다.
또한 두 유저 중 한 유저만 삭제되더라도 같이 삭제되어야 하는 데이터이므로 cascade remove 설정했습니다!

### BlockRepository
차단 정보는 간단한 CRUD 작업만 필요하기 때문에 따로 repository 인터페이스, 구현체 구조를 사용하지 않고 spring-data-jpa를 이용해 단순하게 구현했습니다!