### PR TITLE
컨텐츠 신고 API 구현

### DIFF
--- a/src/main/java/com/first/flash/account/member/application/ReportService.java
+++ b/src/main/java/com/first/flash/account/member/application/ReportService.java
@@ -1,0 +1,31 @@
+package com.first.flash.account.member.application;
+
+import com.first.flash.account.member.application.dto.MemberReportRequest;
+import com.first.flash.account.member.application.dto.MemberReportResponse;
+import com.first.flash.account.member.domain.Member;
+import com.first.flash.account.member.domain.MemberReport;
+import com.first.flash.account.member.infrastructure.ReportRepository;
+import com.first.flash.global.util.AuthUtil;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportService {
+
+    private final ReportRepository repository;
+    private final MemberService memberService;
+
+    @Transactional
+    public MemberReportResponse reportMember(final UUID reportedUserId, final MemberReportRequest request) {
+        UUID reporterId = AuthUtil.getId();
+        Member reporter = memberService.findById(reporterId);
+        Member reportedMember = memberService.findById(reportedUserId);
+        MemberReport memberReport = MemberReport.reportMember(request.reason(), reporter, reportedMember);
+        repository.save(memberReport);
+        return MemberReportResponse.toDto(reportedMember, request.reason());
+    }
+}

--- a/src/main/java/com/first/flash/account/member/application/ReportService.java
+++ b/src/main/java/com/first/flash/account/member/application/ReportService.java
@@ -16,16 +16,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ReportService {
 
-    private final ReportRepository repository;
+    private final ReportRepository reportRepository;
     private final MemberService memberService;
 
     @Transactional
-    public MemberReportResponse reportMember(final UUID reportedUserId, final MemberReportRequest request) {
+    public MemberReportResponse reportMember(final Long reportedContentId,
+        final MemberReportRequest request) {
         UUID reporterId = AuthUtil.getId();
         Member reporter = memberService.findById(reporterId);
-        Member reportedMember = memberService.findById(reportedUserId);
-        MemberReport memberReport = MemberReport.reportMember(request.reason(), reporter, reportedMember);
-        repository.save(memberReport);
-        return MemberReportResponse.toDto(reportedMember, request.reason());
+        MemberReport memberReport = MemberReport.reportContent(request.reason(), reporter,
+            reportedContentId);
+        reportRepository.save(memberReport);
+        return MemberReportResponse.toDto(reportedContentId, request.reason());
     }
 }

--- a/src/main/java/com/first/flash/account/member/application/dto/MemberReportRequest.java
+++ b/src/main/java/com/first/flash/account/member/application/dto/MemberReportRequest.java
@@ -1,0 +1,7 @@
+package com.first.flash.account.member.application.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record MemberReportRequest(@NotEmpty(message = "신고 사유는 필수입니다.") String reason) {
+
+}

--- a/src/main/java/com/first/flash/account/member/application/dto/MemberReportResponse.java
+++ b/src/main/java/com/first/flash/account/member/application/dto/MemberReportResponse.java
@@ -1,13 +1,8 @@
 package com.first.flash.account.member.application.dto;
 
-import com.first.flash.account.member.domain.Member;
-import java.util.UUID;
+public record MemberReportResponse(Long reportedContentId, String reason) {
 
-public record MemberReportResponse(UUID reportedMemberId, String reportedMemberName,
-                                   String reason) {
-
-    public static MemberReportResponse toDto(final Member reportedMember, final String reason) {
-        return new MemberReportResponse(reportedMember.getId(),
-            reportedMember.getNickName(), reason);
+    public static MemberReportResponse toDto(final Long reportedContentId, final String reason) {
+        return new MemberReportResponse(reportedContentId, reason);
     }
 }

--- a/src/main/java/com/first/flash/account/member/application/dto/MemberReportResponse.java
+++ b/src/main/java/com/first/flash/account/member/application/dto/MemberReportResponse.java
@@ -1,0 +1,13 @@
+package com.first.flash.account.member.application.dto;
+
+import com.first.flash.account.member.domain.Member;
+import java.util.UUID;
+
+public record MemberReportResponse(UUID reportedMemberId, String reportedMemberName,
+                                   String reason) {
+
+    public static MemberReportResponse toDto(final Member reportedMember, final String reason) {
+        return new MemberReportResponse(reportedMember.getId(),
+            reportedMember.getNickName(), reason);
+    }
+}

--- a/src/main/java/com/first/flash/account/member/domain/MemberReport.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberReport.java
@@ -24,18 +24,16 @@ public class MemberReport extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     @JoinColumn(name = "reporterId")
     private Member reporter;
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "reportedId")
-    private Member reported;
+    private Long reportedContentId;
 
-    private MemberReport(final String reason, final Member reporter, final Member reported) {
+    private MemberReport(final String reason, final Member reporter, final Long reportedContentId) {
         this.reason = reason;
         this.reporter = reporter;
-        this.reported = reported;
+        this.reportedContentId = reportedContentId;
     }
 
-    public static MemberReport reportMember(final String reason, final Member reporter,
-        final Member reported) {
-        return new MemberReport(reason, reporter, reported);
+    public static MemberReport reportContent(final String reason, final Member reporter,
+        final Long reportedContentId) {
+        return new MemberReport(reason, reporter, reportedContentId);
     }
 }

--- a/src/main/java/com/first/flash/account/member/domain/MemberReport.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberReport.java
@@ -1,0 +1,41 @@
+package com.first.flash.account.member.domain;
+
+import com.first.flash.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MemberReport extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String reason;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "reporterId")
+    private Member reporter;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "reportedId")
+    private Member reported;
+
+    private MemberReport(final String reason, final Member reporter, final Member reported) {
+        this.reason = reason;
+        this.reporter = reporter;
+        this.reported = reported;
+    }
+
+    public static MemberReport reportMember(final String reason, final Member reporter,
+        final Member reported) {
+        return new MemberReport(reason, reporter, reported);
+    }
+}

--- a/src/main/java/com/first/flash/account/member/infrastructure/ReportRepository.java
+++ b/src/main/java/com/first/flash/account/member/infrastructure/ReportRepository.java
@@ -1,0 +1,9 @@
+package com.first.flash.account.member.infrastructure;
+
+import com.first.flash.account.member.domain.MemberReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportRepository extends JpaRepository<MemberReport, Long> {
+
+    MemberReport save(final MemberReport memberReport);
+}

--- a/src/main/java/com/first/flash/account/member/ui/MemberController.java
+++ b/src/main/java/com/first/flash/account/member/ui/MemberController.java
@@ -108,7 +108,8 @@ public class MemberController {
 
     @PostMapping("/reports/{reportedUserId}")
     public ResponseEntity<MemberReportResponse> reportMember(
-        @PathVariable final UUID reportedUserId, @RequestBody @Valid final MemberReportRequest request) {
-        return ResponseEntity.ok(reportService.reportMember(reportedUserId, request));
+        @PathVariable final Long reportedContentId,
+        @RequestBody @Valid final MemberReportRequest request) {
+        return ResponseEntity.ok(reportService.reportMember(reportedContentId, request));
     }
 }

--- a/src/main/java/com/first/flash/account/member/ui/MemberController.java
+++ b/src/main/java/com/first/flash/account/member/ui/MemberController.java
@@ -106,7 +106,12 @@ public class MemberController {
         return ResponseEntity.ok(blockService.blockMember(blockedUserId));
     }
 
-    @PostMapping("/reports/{reportedUserId}")
+    @Operation(summary = "컨텐츠 신고", description = "특정 컨텐츠 신고")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberReportRequest.class)))
+    })
+    @PostMapping("/reports/{reportedContentId}")
     public ResponseEntity<MemberReportResponse> reportMember(
         @PathVariable final Long reportedContentId,
         @RequestBody @Valid final MemberReportRequest request) {

--- a/src/main/java/com/first/flash/account/member/ui/MemberController.java
+++ b/src/main/java/com/first/flash/account/member/ui/MemberController.java
@@ -2,12 +2,15 @@ package com.first.flash.account.member.ui;
 
 import com.first.flash.account.member.application.BlockService;
 import com.first.flash.account.member.application.MemberService;
+import com.first.flash.account.member.application.ReportService;
 import com.first.flash.account.member.application.dto.ConfirmNickNameRequest;
 import com.first.flash.account.member.application.dto.ConfirmNickNameResponse;
 import com.first.flash.account.member.application.dto.MemberBlockResponse;
 import com.first.flash.account.member.application.dto.MemberCompleteRegistrationRequest;
 import com.first.flash.account.member.application.dto.MemberCompleteRegistrationResponse;
 import com.first.flash.account.member.application.dto.MemberInfoResponse;
+import com.first.flash.account.member.application.dto.MemberReportRequest;
+import com.first.flash.account.member.application.dto.MemberReportResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -35,6 +38,7 @@ public class MemberController {
 
     private final MemberService memberService;
     private final BlockService blockService;
+    private final ReportService reportService;
 
     @Operation(summary = "내 정보 조회", description = "특정 회원 정보 조회")
     @ApiResponses(value = {
@@ -100,5 +104,11 @@ public class MemberController {
     @PostMapping("/blocks/{blockedUserId}")
     public ResponseEntity<MemberBlockResponse> blockMember(@PathVariable final UUID blockedUserId) {
         return ResponseEntity.ok(blockService.blockMember(blockedUserId));
+    }
+
+    @PostMapping("/reports/{reportedUserId}")
+    public ResponseEntity<MemberReportResponse> reportMember(
+        @PathVariable final UUID reportedUserId, @RequestBody @Valid final MemberReportRequest request) {
+        return ResponseEntity.ok(reportService.reportMember(reportedUserId, request));
     }
 }


### PR DESCRIPTION
## 구현 내용
![image](https://github.com/user-attachments/assets/d521470c-0bf5-40d8-8708-0019b91c901c)

### MemberReport
신고 정보를 저장하는 MemberReport 엔티티를 생성했습니다!
해당 정보는 차단한 유저, 차단 당한 컨텐츠 모두와  N:1 관계를 맺고 있습니다.
또한 신고자가 삭제될 경우 모든 신고 기록이 삭제디어야하므로 MemberReport 또한 cascade REMOVE를 적용했습니다.

### ReportRepository

신고 정보 또한 간단한 CRUD 작업만 필요하기 때문에 따로 repository 인터페이스, 구현체 구조를 사용하지 않고 spring-data-jpa를 이용해 단순하게 구현했습니다!

### ReportContentType
이후 유저가 올리는 컨텐츠의 타입이 많아지면,(ex solution, comment 등) 컨텐츠의 타입을 나누는 방법이 있을 것 같습니다. 하지만 이번 단계에선 쓰이지 않을 것 같아 구현하지 않았습니다!