### PR TITLE
회원 탈퇴 API 추가

### DIFF
--- a/src/main/java/com/first/flash/account/member/application/MemberService.java
+++ b/src/main/java/com/first/flash/account/member/application/MemberService.java
@@ -55,6 +55,14 @@ public class MemberService {
         Member member = findById(id);
         return MemberInfoResponse.toDto(member);
     }
+
+    @Transactional
+    public MemberInfoResponse deleteMember() {
+        Member member = findMemberByAuthInfo();
+        memberRepository.deleteById(member.getId());
+        return MemberInfoResponse.toDto(member);
+    }
+
     private Member findMemberByAuthInfo() {
         UUID id = AuthUtil.getId();
         return findById(id);

--- a/src/main/java/com/first/flash/account/member/application/MemberService.java
+++ b/src/main/java/com/first/flash/account/member/application/MemberService.java
@@ -6,9 +6,11 @@ import com.first.flash.account.member.application.dto.MemberCompleteRegistration
 import com.first.flash.account.member.application.dto.MemberCompleteRegistrationResponse;
 import com.first.flash.account.member.application.dto.MemberInfoResponse;
 import com.first.flash.account.member.domain.Member;
+import com.first.flash.account.member.domain.MemberDeletedEvent;
 import com.first.flash.account.member.domain.MemberRepository;
 import com.first.flash.account.member.exception.exceptions.MemberNotFoundException;
 import com.first.flash.account.member.exception.exceptions.NickNameDuplicatedException;
+import com.first.flash.global.event.Events;
 import com.first.flash.global.util.AuthUtil;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -51,8 +53,7 @@ public class MemberService {
     }
 
     public MemberInfoResponse getMyInfo() {
-        UUID id = AuthUtil.getId();
-        Member member = findById(id);
+        Member member = findMemberByAuthInfo();
         return MemberInfoResponse.toDto(member);
     }
 
@@ -60,6 +61,7 @@ public class MemberService {
     public MemberInfoResponse deleteMember() {
         Member member = findMemberByAuthInfo();
         memberRepository.deleteById(member.getId());
+        Events.raise(MemberDeletedEvent.of(member.getId()));
         return MemberInfoResponse.toDto(member);
     }
 

--- a/src/main/java/com/first/flash/account/member/application/MemberService.java
+++ b/src/main/java/com/first/flash/account/member/application/MemberService.java
@@ -55,4 +55,8 @@ public class MemberService {
         Member member = findById(id);
         return MemberInfoResponse.toDto(member);
     }
+    private Member findMemberByAuthInfo() {
+        UUID id = AuthUtil.getId();
+        return findById(id);
+    }
 }

--- a/src/main/java/com/first/flash/account/member/domain/MemberDeletedEvent.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberDeletedEvent.java
@@ -1,0 +1,17 @@
+package com.first.flash.account.member.domain;
+
+import com.first.flash.global.event.Event;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberDeletedEvent extends Event {
+
+    private final UUID memberId;
+
+    public static MemberDeletedEvent of(final UUID memberId) {
+        return new MemberDeletedEvent(memberId);
+    }
+}

--- a/src/main/java/com/first/flash/account/member/domain/MemberRepository.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberRepository.java
@@ -6,7 +6,12 @@ import java.util.UUID;
 public interface MemberRepository {
 
     Member save(final Member member);
+
     Optional<Member> findById(final UUID id);
+
     Optional<Member> findBySocialId(final String socialId);
+
     boolean existsByNickName(final String nickName);
+
+    void deleteById(final UUID id);
 }

--- a/src/main/java/com/first/flash/account/member/infrastructure/MemberJpaRepository.java
+++ b/src/main/java/com/first/flash/account/member/infrastructure/MemberJpaRepository.java
@@ -14,4 +14,6 @@ public interface MemberJpaRepository extends JpaRepository<Member, UUID> {
     Optional<Member> findMemberBySocialId(final String email);
 
     boolean existsByNickName(final String nickName);
+
+    void deleteById(final UUID id);
 }

--- a/src/main/java/com/first/flash/account/member/infrastructure/MemberRepositoryImpl.java
+++ b/src/main/java/com/first/flash/account/member/infrastructure/MemberRepositoryImpl.java
@@ -32,4 +32,9 @@ public class MemberRepositoryImpl implements MemberRepository {
     public boolean existsByNickName(final String nickName) {
         return jpaRepository.existsByNickName(nickName);
     }
+
+    @Override
+    public void deleteById(final UUID id) {
+        jpaRepository.deleteById(id);
+    }
 }

--- a/src/main/java/com/first/flash/account/member/ui/MemberController.java
+++ b/src/main/java/com/first/flash/account/member/ui/MemberController.java
@@ -93,6 +93,11 @@ public class MemberController {
         return ResponseEntity.ok(memberService.confirmNickName(request));
     }
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberInfoResponse.class)))
+    })
     @DeleteMapping
     public ResponseEntity<MemberInfoResponse> deleteMember() {
         return ResponseEntity.ok(memberService.deleteMember());

--- a/src/main/java/com/first/flash/account/member/ui/MemberController.java
+++ b/src/main/java/com/first/flash/account/member/ui/MemberController.java
@@ -22,6 +22,7 @@ import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -90,6 +91,11 @@ public class MemberController {
     public ResponseEntity<ConfirmNickNameResponse> confirmNickName(
         @Valid @RequestBody final ConfirmNickNameRequest request) {
         return ResponseEntity.ok(memberService.confirmNickName(request));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<MemberInfoResponse> deleteMember() {
+        return ResponseEntity.ok(memberService.deleteMember());
     }
 
     @Operation(summary = "유저 차단", description = "특정 유저 차단")


### PR DESCRIPTION
## 작업 내용
### 회원 엔티티 삭제 API 추가
spring-data-jpa 메서드를 이용해 간단하게 구현했습니다.

### 회원 삭제 이벤트 발송
```java
memberRepository.deleteById(member.getId());
Events.raise(MemberDeletedEvent.of(member.getId()));
```
위처럼 회원 삭제 이후 회원이 삭제됨 이벤트를 발송하도록 했습니다.
회원이 올린 컨텐츠 애그리거트에서 이를 구독하고 전체 삭제하면 될 것 같습니다!