### PR TITLE
해설 리스트 필드 추가

### DIFF
--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -62,7 +62,8 @@ public class SolutionService {
         Solution solution = solutionRepository.findById(id)
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
 
-        validateUploader(solution);
+        UUID uploaderId = solution.getUploaderDetail().getUploaderId();
+        validateUploader(uploaderId);
 
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl());
 
@@ -76,15 +77,15 @@ public class SolutionService {
         Solution solution = solutionRepository.findById(id)
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
 
-        validateUploader(solution);
+        UUID uploaderId = solution.getUploaderDetail().getUploaderId();
+        validateUploader(uploaderId);
 
         solutionRepository.deleteById(id);
 
         Events.raise(SolutionDeletedEvent.of(problemId));
     }
 
-    private void validateUploader(final Solution solution) {
-        UUID uploaderId = solution.getUploaderDetail().getUploaderId();
+    private void validateUploader(final UUID uploaderId) {
         if (!AuthUtil.isSameId(uploaderId)) {
             throw new SolutionAccessDeniedException();
         }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -41,6 +41,11 @@ public class SolutionService {
         return new SolutionsResponseDto(solutions, new SolutionMetaResponseDto(solutions.size()));
     }
 
+    public SolutionsResponseDto findMySolutions() {
+        UUID myId = AuthUtil.getId();
+        return findAllSolutionsByMemberId(myId);
+    }
+
     public SolutionsResponseDto findAllSolutionsByMemberId(final UUID memberId) {
         List<SolutionResponseDto> solutions = solutionRepository.findAllByUploaderId(memberId)
                                                                 .stream()

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -56,6 +56,7 @@ public class SolutionService {
 
         Solution solution = solutionRepository.findById(id)
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
+
         validateUploader(solution);
 
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl());
@@ -69,6 +70,7 @@ public class SolutionService {
 
         Solution solution = solutionRepository.findById(id)
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
+
         validateUploader(solution);
 
         solutionRepository.deleteById(id);
@@ -77,10 +79,8 @@ public class SolutionService {
     }
 
     private void validateUploader(final Solution solution) {
-        UUID currentUserId = AuthUtil.getId();
         UUID uploaderId = solution.getUploaderDetail().getUploaderId();
-
-        if (!uploaderId.equals(currentUserId)) {
+        if (!AuthUtil.isSameId(uploaderId)) {
             throw new SolutionAccessDeniedException();
         }
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
@@ -3,9 +3,10 @@ package com.first.flash.climbing.solution.application.dto;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
 import com.first.flash.climbing.solution.domain.vo.UploaderDetail;
+import java.util.UUID;
 
 public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
-                                  String videoUrl) {
+                                  String videoUrl, UUID uploaderId) {
 
     public static SolutionResponseDto toDto(final Solution solution) {
         SolutionDetail solutionDetail = solution.getSolutionDetail();
@@ -13,6 +14,6 @@ public record SolutionResponseDto(Long id, String uploader, String review, Strin
 
         return new SolutionResponseDto(solution.getId(), uploaderDetail.getUploader(),
             solutionDetail.getReview(), uploaderDetail.getInstagramId(),
-            solutionDetail.getVideoUrl());
+            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
@@ -13,8 +13,8 @@ public record SolutionResponseDto(Long id, String uploader, String review, Strin
         SolutionDetail solutionDetail = solution.getSolutionDetail();
         UploaderDetail uploaderDetail = solution.getUploaderDetail();
 
-        UUID currentUserId = AuthUtil.getId();
-        boolean isUploader = uploaderDetail.getUploaderId().equals(currentUserId);
+        UUID uploaderId = uploaderDetail.getUploaderId();
+        Boolean isUploader = AuthUtil.isSameId(uploaderId);
 
         return new SolutionResponseDto(solution.getId(), uploaderDetail.getUploader(),
             solutionDetail.getReview(), uploaderDetail.getInstagramId(),

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
@@ -3,17 +3,21 @@ package com.first.flash.climbing.solution.application.dto;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
 import com.first.flash.climbing.solution.domain.vo.UploaderDetail;
+import com.first.flash.global.util.AuthUtil;
 import java.util.UUID;
 
 public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
-                                  String videoUrl, UUID uploaderId) {
+                                  String videoUrl, UUID uploaderId, Boolean isUploader) {
 
     public static SolutionResponseDto toDto(final Solution solution) {
         SolutionDetail solutionDetail = solution.getSolutionDetail();
         UploaderDetail uploaderDetail = solution.getUploaderDetail();
 
+        UUID currentUserId = AuthUtil.getId();
+        boolean isUploader = uploaderDetail.getUploaderId().equals(currentUserId);
+
         return new SolutionResponseDto(solution.getId(), uploaderDetail.getUploader(),
             solutionDetail.getReview(), uploaderDetail.getInstagramId(),
-            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId());
+            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId(), isUploader);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.exception;
 
+import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeniedException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import com.first.flash.global.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,14 @@ public class SolutionExceptionHandler {
         final SolutionNotFoundException exception) {
         ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                             .body(errorResponse);
+    }
+
+    @ExceptionHandler(SolutionAccessDeniedException.class)
+    public ResponseEntity<ErrorResponseDto> handleSolutionAccessDeniedException(
+        final SolutionAccessDeniedException exception) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
                              .body(errorResponse);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionAccessDeniedException.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionAccessDeniedException.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.solution.exception.exceptions;
+
+public class SolutionAccessDeniedException extends RuntimeException {
+
+    public SolutionAccessDeniedException() {
+        super("해당 해설에 접근할 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -98,6 +98,10 @@ public class SolutionController {
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "요청값 누락", value = "{\"videoUrl\": \"비디오 URL은 필수입니다.\"}"),
             })),
+        @ApiResponse(responseCode = "403", description = "본인의 해설이 아님",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "수정 권한 없음", value = "{\"error\": \"해당 해설에 접근할 권한이 없습니다.\"}"),
+            })),
         @ApiResponse(responseCode = "404", description = "리소스를 찾을 수 없음",
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "해설 없음", value = "{\"error\": \"아이디가 1인 해설을 찾을 수 없습니다.\"}")
@@ -118,6 +122,10 @@ public class SolutionController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "204", description = "성공적으로 해설을 수정함",
             content = @Content(mediaType = "application/json")),
+        @ApiResponse(responseCode = "403", description = "본인의 해설이 아님",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "삭제 권한 없음", value = "{\"error\": \"해당 해설에 접근할 권한이 없습니다.\"}"),
+            })),
         @ApiResponse(responseCode = "404", description = "리소스를 찾을 수 없음",
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "문제 없음", value = "{\"error\": \"아이디가 0190c558-9063-7050-b4fc-eb421e3236b3인 문제를 찾을 수 없습니다.\"}"),

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -6,6 +6,7 @@ import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+import com.first.flash.global.util.AuthUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -35,6 +36,19 @@ public class SolutionController {
 
     private final SolutionService solutionService;
     private final SolutionSaveService solutionSaveService;
+
+    @Operation(summary = "해설 조회", description = "본인이 등록한 해설 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 해설을 조회함",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionsResponseDto.class)))
+    })
+    @GetMapping("solutions")
+    public ResponseEntity<SolutionsResponseDto> getMySolutions() {
+        UUID myId = AuthUtil.getId();
+        SolutionsResponseDto response = solutionService.findAllSolutionsByMemberId(myId);
+
+        return ResponseEntity.ok(response);
+    }
 
     @Operation(summary = "해설 조회", description = "특정 문제에 대한 해설 조회")
     @ApiResponses(value = {

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -6,7 +6,6 @@ import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
-import com.first.flash.global.util.AuthUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -44,8 +43,7 @@ public class SolutionController {
     })
     @GetMapping("solutions")
     public ResponseEntity<SolutionsResponseDto> getMySolutions() {
-        UUID myId = AuthUtil.getId();
-        SolutionsResponseDto response = solutionService.findAllSolutionsByMemberId(myId);
+        SolutionsResponseDto response = solutionService.findMySolutions();
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/first/flash/global/util/AuthUtil.java
+++ b/src/main/java/com/first/flash/global/util/AuthUtil.java
@@ -13,6 +13,10 @@ public class AuthUtil {
         return UUID.fromString((String) authentication.getPrincipal());
     }
 
+    public static Boolean isSameId(UUID id) {
+        return getId().equals(id);
+    }
+
     public static Collection<? extends GrantedAuthority> getRoles() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return authentication.getAuthorities();

--- a/src/main/java/com/first/flash/global/util/AuthUtil.java
+++ b/src/main/java/com/first/flash/global/util/AuthUtil.java
@@ -13,7 +13,7 @@ public class AuthUtil {
         return UUID.fromString((String) authentication.getPrincipal());
     }
 
-    public static Boolean isSameId(UUID id) {
+    public static Boolean isSameId(final UUID id) {
         return getId().equals(id);
     }
 


### PR DESCRIPTION
# 요약

유저 기능이 추가됨에 따라 해설 리스트를 반환할 때 필요한 필드를 추가하였습니다.

# 내용

## 차단, 신고 기능 구현을 위한 필드 추가

```json
{
  "solutions": [
    {
      "id": 0,
      "uploader": "string",
      "review": "string",
      "instagramId": "string",
      "videoUrl": "string",
      "uploaderId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
      "isUploader": true
    }
  ],
  "meta": {
    "count": 0
  }
}
```

- `uploaderId` 필드, `isUploader` 필드 추가
  - `uploaderId` 필드는 해당 유저 신고, 차단을 하기 위함
  - `isUploader` 필드는 차단 신고, 수정 삭제 필드를 구분하기 위함
- `isUploader`: `uploaderId`와 현재 요청한 유저의 Id가 같은 경우 true, 아니면 false를 반환

## 수정 삭제 시 검증 추가

- 본인 영상에 대해서만 수정 삭제가 가능하도록 검증 추가
```java
// SolutionService

    private void validateUploader(final Solution solution) {
        UUID currentUserId = AuthUtil.getId();
        UUID uploaderId = solution.getUploaderDetail().getUploaderId();

        if (!uploaderId.equals(currentUserId)) {
            throw new SolutionAccessDeniedException();
        }
    }
```

- 수정, 삭제 요청의 대상이 된 `Solution`의 `uploaderId`와 요청한 유저의 Id를 비교
- 두 아이디가 다른 경우 `SolutionAccessDeniedException` 발생 -> `403 Forbidden` 응답

## 내가 업로드한 해설 리스트 반환

### GET /solutions

- 요청한 유저의 id에 해당하는 해설 리스트 반환