### PR TITLE
Spring AOP를 활용한 logging

### DIFF
--- a/src/main/java/com/first/flash/account/member/domain/Gender.java
+++ b/src/main/java/com/first/flash/account/member/domain/Gender.java
@@ -1,5 +1,8 @@
 package com.first.flash.account.member.domain;
 
+import lombok.ToString;
+
+@ToString
 public enum Gender {
 
     MALE, FEMALE;

--- a/src/main/java/com/first/flash/account/member/domain/Member.java
+++ b/src/main/java/com/first/flash/account/member/domain/Member.java
@@ -10,12 +10,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Getter
+@ToString
 public class Member {
 
     @Id

--- a/src/main/java/com/first/flash/account/member/domain/MemberBlock.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberBlock.java
@@ -11,10 +11,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@ToString
 public class MemberBlock extends BaseEntity {
 
     @Id

--- a/src/main/java/com/first/flash/account/member/domain/MemberReport.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberReport.java
@@ -11,10 +11,12 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@ToString
 public class MemberReport extends BaseEntity {
 
     @Id

--- a/src/main/java/com/first/flash/account/member/domain/Role.java
+++ b/src/main/java/com/first/flash/account/member/domain/Role.java
@@ -1,8 +1,10 @@
 package com.first.flash.account.member.domain;
 
 import lombok.AllArgsConstructor;
+import lombok.ToString;
 
 @AllArgsConstructor
+@ToString
 public enum Role {
 
     ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER");

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGym.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGym.java
@@ -15,11 +15,13 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@ToString
 public class ClimbingGym {
 
     @Id

--- a/src/main/java/com/first/flash/climbing/gym/domian/vo/Difficulty.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/vo/Difficulty.java
@@ -6,11 +6,13 @@ import jakarta.validation.constraints.NotNull;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Embeddable
 @NoArgsConstructor
 @EqualsAndHashCode
 @Getter
+@ToString
 public class Difficulty {
 
     @NotEmpty(message = "난이도 이름은 필수입니다.")

--- a/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
@@ -10,12 +10,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @Getter
+@ToString
 public class Problem {
 
     private static final Long DEFAULT_OPTIONAL_WEIGHT = 0L;

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
@@ -27,6 +28,7 @@ import lombok.NoArgsConstructor;
             columnList = "isExpired, recommendationValue, id")
     }
 )
+@ToString
 public class QueryProblem {
 
     private static final Boolean DEFAULT_HAS_SOLUTION = false;

--- a/src/main/java/com/first/flash/climbing/problem/domain/vo/DifficultyInfo.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/vo/DifficultyInfo.java
@@ -4,11 +4,13 @@ import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Embeddable
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@ToString
 public class DifficultyInfo {
 
     private String difficultyName;

--- a/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
@@ -11,11 +11,13 @@ import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@ToString
 public class Sector {
 
     @Id

--- a/src/main/java/com/first/flash/climbing/sector/domain/vo/RemovalInfo.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/vo/RemovalInfo.java
@@ -5,11 +5,13 @@ import java.time.LocalDate;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Embeddable
 @NoArgsConstructor
 @EqualsAndHashCode
 @Getter
+@ToString
 public class RemovalInfo {
 
     private static final int FAKE_SECTOR_LIFETIME_DAYS = 30;

--- a/src/main/java/com/first/flash/climbing/sector/domain/vo/SectorName.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/vo/SectorName.java
@@ -4,11 +4,13 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Embeddable
 @NoArgsConstructor
 @EqualsAndHashCode
 @Getter
+@ToString
 public class SectorName {
     private String name;
     private String adminName;

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -12,11 +12,13 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@ToString
 public class Solution extends BaseEntity {
 
     private static final Long DEFAULT_OPTIONAL_WEIGHT = 0L;

--- a/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
@@ -4,11 +4,13 @@ import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Embeddable
 @NoArgsConstructor
 @EqualsAndHashCode
 @Getter
+@ToString
 public class SolutionDetail {
 
     private String review;

--- a/src/main/java/com/first/flash/climbing/solution/domain/vo/UploaderDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/vo/UploaderDetail.java
@@ -6,11 +6,13 @@ import java.util.UUID;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Embeddable
 @NoArgsConstructor
 @EqualsAndHashCode
 @Getter
+@ToString
 public class UploaderDetail {
 
     @Column(columnDefinition = "BINARY(16)")

--- a/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
+++ b/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
@@ -1,0 +1,104 @@
+package com.first.flash.global.aspect;
+
+import com.first.flash.global.util.AuthUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import java.lang.reflect.Method;
+import java.util.Enumeration;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Aspect
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LoggingAspect {
+
+    @Before("com.first.flash.global.aspect.PointCuts.allController()")
+    public void doBeforeController() {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+            .getRequest();
+
+        log.info("======= Controller Start =======");
+        log.info("Request URI: {}", request.getRequestURI());
+        log.info("HTTP Method: {}", request.getMethod());
+
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            log.info("Header: {} = {}", headerName, request.getHeader(headerName));
+        }
+
+        Enumeration<String> parameterNames = request.getParameterNames();
+        while (parameterNames.hasMoreElements()) {
+            String parameterName = parameterNames.nextElement();
+            log.info("Parameter: {} = {}", parameterName, request.getParameter(parameterName));
+        }
+    }
+
+    @Before("com.first.flash.global.aspect.PointCuts.verifiedControllers()")
+    public void doBeforeVerifiedController() {
+        log.info("user id: {}", AuthUtil.getId());
+    }
+
+    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allController()", returning = "result")
+    public void afterReturnController(final Object result) {
+        if (result instanceof ResponseEntity<?> responseEntity) {
+            int statusCode = responseEntity.getStatusCode().value();
+            Object responseBody = responseEntity.getBody();
+
+            log.info("Response Status Code: {}", statusCode);
+            if (!Objects.isNull(responseBody)) {
+                log.info("Response Body: {}", responseBody);
+            } else {
+                log.info("no Response Body");
+            }
+        } else {
+            if (!Objects.isNull(result)) {
+                log.info("Response: {}", result);
+            } else {
+                log.info("no Response");
+            }
+        }
+        log.info("======= Controller End =======");
+    }
+
+    @Before("com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()")
+    public void doBefore(final JoinPoint joinPoint) {
+        Method method = getMethod(joinPoint);
+        String objectName = joinPoint.getTarget()
+                                     .getClass()
+                                     .getSimpleName();
+        log.info("======= {} Start =======", objectName);
+        log.info("method name = {}", method.getName());
+        Object[] args = joinPoint.getArgs();
+        for (Object arg : args) {
+            log.info("parameter type = {}", arg.getClass().getSimpleName());
+            log.info("parameter value = {}", arg);
+        }
+    }
+
+    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
+    public void afterReturnLog(final JoinPoint joinPoint, final Object result) {
+        log.info("return type = {}", result.getClass().getSimpleName());
+        log.info("return value = {}", result);
+        String objectName = joinPoint.getTarget()
+                                     .getClass()
+                                     .getSimpleName();
+        log.info("======= {} End =======", objectName);
+    }
+
+    private Method getMethod(final JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        return signature.getMethod();
+    }
+}

--- a/src/main/java/com/first/flash/global/aspect/PointCuts.java
+++ b/src/main/java/com/first/flash/global/aspect/PointCuts.java
@@ -1,0 +1,23 @@
+package com.first.flash.global.aspect;
+
+import org.aspectj.lang.annotation.Pointcut;
+
+public class PointCuts {
+
+    @Pointcut("execution(* com.first.flash..*Controller.*(..))")
+    public void allController() {
+    }
+
+    @Pointcut("execution(* com.first.flash..*Service*.*(..))")
+    public void allService() {
+    }
+
+    @Pointcut("execution(* com.first.flash..*Repository*.*(..))")
+    public void allRepository() {
+    }
+
+    @Pointcut("execution(* com.first.flash.climbing..*Controller.*(..))")
+    public void verifiedControllers() {
+
+    }
+}


### PR DESCRIPTION
# 요약
Controller, Service, Reposiotry 객체들의 info 로그를 볼 수 있도록 했습니다.
# 내용
## 각 객체의 로그 형식
### Controller
Controller로 들어오는 요청은 아래와 같이 표시됩니다.
```
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : ======= Controller Start =======
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Request URI: /gyms
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : HTTP Method: GET
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: authorization = Bearer token...
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: user-agent = PostmanRuntime/7.32.3
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: accept = */*
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: cache-control = no-cache
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: postman-token = c7e387c4-dc87-40f2-99e8-f37ce1954864
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: host = localhost:8080
2024-08-31T17:01:49.201+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: accept-encoding = gzip, deflate, br
2024-08-31T17:01:49.202+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : Header: connection = keep-alive
2024-08-31T17:01:49.202+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : user id: bddbf021-30ff-4258-a289-824d3ddfd32e
```

주요 요소는 다음과 같습니다.
- Request URI
- HTTP Method
- Header
- user id
user id는 해당 요청이 인증된 유저만 보낼 수 있는 요청일 때만 출력됩니다.

### Service
Service로 들어오는 요청은 아래와 같이 표시됩니다.
```
2024-08-31T17:01:49.202+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : ======= ClimbingGymService Start =======
2024-08-31T17:01:49.202+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : method name = findAllClimbingGyms
...
2024-08-31T17:01:49.214+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : return type = ListN
2024-08-31T17:01:49.214+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : return value = []
2024-08-31T17:01:49.214+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : ======= ClimbingGymService End =======
```

주요 요소는 다음과 같습니다.
- 실행되는 메서드 명
- 메서드 파라미터 값
- 리턴 타입
- 리턴 값

### Repository
Repository로 들어오는 요청은 아래와 같이 표시됩니다.
```
2024-08-31T17:01:49.203+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : ======= ClimbingGymRepositoryImpl Start =======
2024-08-31T17:01:49.203+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : method name = findAll
2024-08-31T17:01:49.204+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : ======= $Proxy177 Start =======
2024-08-31T17:01:49.204+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : method name = findAll
Hibernate: 
    select
        cg1_0.id,
        cg1_0.gym_name,
        cg1_0.map_image_url,
        cg1_0.thumbnail_url 
    from
        climbing_gym cg1_0
2024-08-31T17:01:49.212+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : return type = ArrayList
2024-08-31T17:01:49.213+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : return value = []
2024-08-31T17:01:49.213+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : ======= $Proxy177 End =======
2024-08-31T17:01:49.213+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : return type = ArrayList
2024-08-31T17:01:49.213+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : return value = []
2024-08-31T17:01:49.213+09:00  INFO 1929 --- [flash] [nio-8080-exec-4] c.f.flash.global.aspect.LoggingAspect    : ======= ClimbingGymRepositoryImpl End =======
```

주요 요소는 다음과 같습니다.
- 실행되는 메서드 명
- 메서드 파라미터 값
- 리턴 타입
- 리턴 값
Serivce와 Repository는 출력 요소가 동일하지만, repository는 중간에 쿼리문 로그가 출력됩니다.

## Spring AOP 활용
로깅이라는 범용적으로 추가하기 위해 Spring AOP를 활용했고, 주요 구성 요소는 다음과 같습니다.
### 포인트컷
포인트컷으로 추가하고자 하는 부가기능이 들어갈 위치를 지정합니다.
```java
@Pointcut("execution(* com.first.flash..*Controller.*(..))")
    public void allController() {
    }
```
이는 flash 패키지 하위에 모든 컨트롤러 객체의 메서드에 부가기능을 적용한다는 것을 의미합니다.

### 어드바이스
어드바이스는 특정 포인트컷에 적용될 부가 기능입니다.
```java
@AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
    public void afterReturnLog(final JoinPoint joinPoint, final Object result) {
        log.info("return type = {}", result.getClass().getSimpleName());
        log.info("return value = {}", result);
        String objectName = joinPoint.getTarget()
                                     .getClass()
                                     .getSimpleName();
        log.info("======= {} End =======", objectName);
    }
```
이는 allService 포인트컷의 메서드가 return 될 때 실행되는 어드바이스입니다.

## 논의할 점
가장 큰 컴포넌트인 Controller, Service, Repository에만 로그를 추가한 것이기 때문에 디테일한 로깅은 논의가 필요할 것 같습니다.
현재 세 컴포넌트에 추가할 로그나 불필요하다고 생각하는 로그가 있다면 그것도 논의해보면 좋을 것 같습니다.

파라미터나 리턴 값에서 엔티티 데이터를 보려면 toString을 추가해야 하는데 이 부분에 대해서도 논의가 필요할 것 같습니다!