### PR TITLE
차단한 유저의 해설 영상 제외

### DIFF
--- a/src/main/java/com/first/flash/account/member/application/BlockService.java
+++ b/src/main/java/com/first/flash/account/member/application/BlockService.java
@@ -5,6 +5,7 @@ import com.first.flash.account.member.domain.Member;
 import com.first.flash.account.member.domain.MemberBlock;
 import com.first.flash.account.member.infrastructure.BlockRepository;
 import com.first.flash.global.util.AuthUtil;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,5 +28,10 @@ public class BlockService {
         MemberBlock blockResult = blockRepository.save(MemberBlock.blockMember(blocker, blocked));
         blockRepository.save(blockResult);
         return MemberBlockResponse.toDto(blocked);
+    }
+
+    public List<UUID> findBlockedMembers() {
+        UUID blockerId = AuthUtil.getId();
+        return blockRepository.findBlockedMembers(blockerId);
     }
 }

--- a/src/main/java/com/first/flash/account/member/infrastructure/BlockRepository.java
+++ b/src/main/java/com/first/flash/account/member/infrastructure/BlockRepository.java
@@ -1,11 +1,18 @@
 package com.first.flash.account.member.infrastructure;
 
 import com.first.flash.account.member.domain.MemberBlock;
+import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BlockRepository extends JpaRepository<MemberBlock, Long> {
 
     MemberBlock save(final MemberBlock memberBlock);
+
+    @Query("SELECT mb.blocked.id FROM MemberBlock mb WHERE mb.blocker.id = :blockerId")
+    List<UUID> findBlockedMembers(@Param("blockerId") final UUID blockerId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.application;
 
+import com.first.flash.account.member.application.BlockService;
 import com.first.flash.climbing.problem.domain.ProblemIdConfirmRequestedEvent;
 import com.first.flash.climbing.solution.application.dto.SolutionMetaResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
@@ -24,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SolutionService {
 
     private final SolutionRepository solutionRepository;
+    private final BlockService blockService;
 
     public Solution findSolutionById(final Long id) {
         return solutionRepository.findById(id)
@@ -32,8 +34,8 @@ public class SolutionService {
 
     public SolutionsResponseDto findAllSolutionsByProblemId(final UUID problemId) {
         Events.raise(ProblemIdConfirmRequestedEvent.of(problemId));
-
-        List<SolutionResponseDto> solutions = solutionRepository.findAllByProblemId(problemId)
+        List<UUID> blockedMembers = blockService.findBlockedMembers();
+        List<SolutionResponseDto> solutions = solutionRepository.findAllByProblemId(problemId, blockedMembers)
                                                                 .stream()
                                                                 .map(SolutionResponseDto::toDto)
                                                                 .toList();

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -10,7 +10,7 @@ public interface SolutionRepository {
 
     Optional<Solution> findById(final Long id);
 
-    List<Solution> findAllByProblemId(final UUID problemId);
+    List<Solution> findAllByProblemId(final UUID problemId, final List<UUID> blockedMembers);
 
     List<Solution> findAllByUploaderId(final UUID uploaderId);
 

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -1,0 +1,25 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import static com.first.flash.climbing.solution.domain.QSolution.solution;
+
+import com.first.flash.climbing.solution.domain.Solution;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SolutionQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public List<Solution> findAllExcludedBlockedMembers(final UUID problemId,
+        final List<UUID> memberIds) {
+        return jpaQueryFactory.selectFrom(solution)
+                              .where(solution.problemId.eq(problemId)
+                                                       .and(solution.uploaderDetail.uploaderId
+                                                           .notIn(memberIds))).fetch();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Repository;
 public class SolutionRepositoryImpl implements SolutionRepository {
 
     private final SolutionJpaRepository solutionJpaRepository;
+    private final SolutionQueryDslRepository solutionQueryDslRepository;
 
     @Override
     public Solution save(final Solution solution) {
@@ -25,8 +26,13 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     }
 
     @Override
-    public List<Solution> findAllByProblemId(final UUID problemId) {
-        return solutionJpaRepository.findByProblemId(problemId);
+    public List<Solution> findAllByProblemId(final UUID problemId,
+        final List<UUID> blockedMembers) {
+        if (blockedMembers.isEmpty()) {
+            return solutionJpaRepository.findByProblemId(problemId);
+        }
+        return solutionQueryDslRepository.findAllExcludedBlockedMembers(
+            problemId, blockedMembers);
     }
 
     @Override


### PR DESCRIPTION
## 요약
차단한 유저들의 해설 영상을 올리지 않도록 구현했습니다.

## 내용
### BlockServcie에 차단한 유저들의 id를 조회하는 메서드 구현
```java
public List<UUID> findBlockedMembers() {
        UUID blockerId = AuthUtil.getId();
        return blockRepository.findBlockedMembers(blockerId);
    }
```
추후에 유저들이 올리는 컨텐츠가 여러 개가 되면, 위 로직이 반복될 것 같아 BlockService에 구현했습니다.

### SolutionService에서 BlockService로부터 차단한 유저들 요청
차단한 유저들의 id 반환이라는 작업이 여러 곳에서 필요할 것 같아서 해당 로직을 사용하는 애그리거트 service에선 어쩔 수 없이 BlockService에 의존해야 할 것 같습니다. 다른 좋은 의견있으시면 남겨주시면 감사하겠습니다!