### PR TITLE
본인이 업로드한 해설 조회&해설 상세 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -39,7 +39,6 @@ public class SolutionSaveService {
     @Transactional
     public void updateUploaderInfo(final UUID uploaderId, final String nickName,
         final String instagramId) {
-        solutionRepository.findAllByUploaderId(uploaderId)
-                          .forEach(solution -> solution.updateUploaderInfo(nickName, instagramId));
+        solutionRepository.updateUploaderInfo(uploaderId, nickName, instagramId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -29,8 +29,7 @@ public class SolutionSaveService {
         Member member = memberService.findById(id);
 
         Solution solution = Solution.of(member.getNickName(), createRequestDto.review(),
-            member.getInstagramId(),
-            createRequestDto.videoUrl(), problemId, member.getId());
+            member.getInstagramId(), createRequestDto.videoUrl(), problemId, member.getId());
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
         return SolutionResponseDto.toDto(savedSolution);

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -76,18 +76,13 @@ public class SolutionService {
     }
 
     @Transactional
-    public void deleteSolution(final Long id, final UUID problemId) {
-        Events.raise(ProblemIdConfirmRequestedEvent.of(problemId));
-
+    public void deleteSolution(final Long id) {
         Solution solution = solutionRepository.findById(id)
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
-
         UUID uploaderId = solution.getUploaderDetail().getUploaderId();
         validateUploader(uploaderId);
-
         solutionRepository.deleteById(id);
-
-        Events.raise(SolutionDeletedEvent.of(problemId));
+        Events.raise(SolutionDeletedEvent.of(solution.getProblemId()));
     }
 
     private void validateUploader(final UUID uploaderId) {

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -2,7 +2,7 @@ package com.first.flash.climbing.solution.application;
 
 import com.first.flash.account.member.application.BlockService;
 import com.first.flash.climbing.problem.domain.ProblemIdConfirmRequestedEvent;
-import com.first.flash.climbing.solution.application.dto.SolutionMetaResponseDto;
+import com.first.flash.climbing.solution.application.dto.MySolutionsResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
@@ -11,6 +11,7 @@ import com.first.flash.climbing.solution.domain.SolutionDeletedEvent;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeniedException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
+import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
 import com.first.flash.global.event.Events;
 import com.first.flash.global.util.AuthUtil;
 import java.util.List;
@@ -35,12 +36,13 @@ public class SolutionService {
     public SolutionsResponseDto findAllSolutionsByProblemId(final UUID problemId) {
         Events.raise(ProblemIdConfirmRequestedEvent.of(problemId));
         List<UUID> blockedMembers = blockService.findBlockedMembers();
-        List<SolutionResponseDto> solutions = solutionRepository.findAllByProblemId(problemId, blockedMembers)
+        List<SolutionResponseDto> solutions = solutionRepository.findAllByProblemId(problemId,
+                                                                    blockedMembers)
                                                                 .stream()
                                                                 .map(SolutionResponseDto::toDto)
                                                                 .toList();
 
-        return new SolutionsResponseDto(solutions, new SolutionMetaResponseDto(solutions.size()));
+        return SolutionsResponseDto.of(solutions);
     }
 
     public MySolutionsResponseDto findMySolutions() {

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -43,18 +43,14 @@ public class SolutionService {
         return new SolutionsResponseDto(solutions, new SolutionMetaResponseDto(solutions.size()));
     }
 
-    public SolutionsResponseDto findMySolutions() {
+    public MySolutionsResponseDto findMySolutions() {
         UUID myId = AuthUtil.getId();
         return findAllSolutionsByMemberId(myId);
     }
 
-    public SolutionsResponseDto findAllSolutionsByMemberId(final UUID memberId) {
-        List<SolutionResponseDto> solutions = solutionRepository.findAllByUploaderId(memberId)
-                                                                .stream()
-                                                                .map(SolutionResponseDto::toDto)
-                                                                .toList();
-
-        return new SolutionsResponseDto(solutions, new SolutionMetaResponseDto(solutions.size()));
+    public MySolutionsResponseDto findAllSolutionsByMemberId(final UUID memberId) {
+        List<MySolutionDto> solutions = solutionRepository.findAllByUploaderId(memberId);
+        return MySolutionsResponseDto.of(solutions);
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -11,6 +11,7 @@ import com.first.flash.climbing.solution.domain.SolutionDeletedEvent;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeniedException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
+import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
 import com.first.flash.global.event.Events;
 import com.first.flash.global.util.AuthUtil;
@@ -31,6 +32,10 @@ public class SolutionService {
     public Solution findSolutionById(final Long id) {
         return solutionRepository.findById(id)
                                  .orElseThrow(() -> new SolutionNotFoundException(id));
+    }
+
+    public DetailSolutionDto findDetailSolutionById(final Long solutionId) {
+        return solutionRepository.findDetailSolutionById(solutionId);
     }
 
     public SolutionsResponseDto findAllSolutionsByProblemId(final UUID problemId) {

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/MySolutionMetaResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/MySolutionMetaResponseDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.climbing.solution.application.dto;
+
+public record MySolutionMetaResponseDto(int count) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/MySolutionsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/MySolutionsResponseDto.java
@@ -1,0 +1,13 @@
+package com.first.flash.climbing.solution.application.dto;
+
+import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
+import java.util.List;
+
+public record MySolutionsResponseDto(List<MySolutionDto> mySolutions,
+                                     MySolutionMetaResponseDto meta) {
+
+    public static MySolutionsResponseDto of(final List<MySolutionDto> mySolutions) {
+        return new MySolutionsResponseDto(mySolutions,
+            new MySolutionMetaResponseDto(mySolutions.size()));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
@@ -5,4 +5,8 @@ import java.util.List;
 public record SolutionsResponseDto(List<SolutionResponseDto> solutions,
                                    SolutionMetaResponseDto meta) {
 
+    public static SolutionsResponseDto of(final List<SolutionResponseDto> solutions) {
+        return new SolutionsResponseDto(solutions,
+            new SolutionMetaResponseDto(solutions.size()));
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.domain;
 
+import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
 import java.util.List;
 import java.util.Optional;
@@ -18,4 +19,6 @@ public interface SolutionRepository {
     void deleteById(final Long id);
 
     void updateUploaderInfo(final UUID uploaderId, final String nickName, final String instagramId);
+
+    DetailSolutionDto findDetailSolutionById(final Long solutionId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -16,4 +16,6 @@ public interface SolutionRepository {
     List<MySolutionDto> findAllByUploaderId(final UUID uploaderId);
 
     void deleteById(final Long id);
+
+    void updateUploaderInfo(final UUID uploaderId, final String nickName, final String instagramId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.domain;
 
+import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -12,7 +13,7 @@ public interface SolutionRepository {
 
     List<Solution> findAllByProblemId(final UUID problemId, final List<UUID> blockedMembers);
 
-    List<Solution> findAllByUploaderId(final UUID uploaderId);
+    List<MySolutionDto> findAllByUploaderId(final UUID uploaderId);
 
     void deleteById(final Long id);
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -48,4 +48,18 @@ public class SolutionQueryDslRepository {
                       .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
                       .execute();
     }
+
+    public DetailSolutionDto findDetailSolutionById(final Long solutionId) {
+        return jpaQueryFactory.select(Projections.constructor(DetailSolutionDto.class,
+                                  solution.id, solution.solutionDetail.videoUrl, queryProblem.gymName,
+                                  queryProblem.sectorName, solution.solutionDetail.review, queryProblem.difficultyName,
+                                  queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
+                              ))
+                              .from(solution)
+                              .innerJoin(queryProblem)
+                              .on(solution.problemId.eq(queryProblem.id))
+                              .where(solution.id.eq(solutionId))
+                              .fetchJoin()
+                              .fetchOne();
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -4,6 +4,7 @@ import static com.first.flash.climbing.problem.domain.QQueryProblem.queryProblem
 import static com.first.flash.climbing.solution.domain.QSolution.solution;
 
 import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -28,9 +29,8 @@ public class SolutionQueryDslRepository {
 
     public List<MySolutionDto> findByUploaderId(final UUID uploaderId) {
         return jpaQueryFactory.select(Projections.constructor(MySolutionDto.class,
-                                  solution.id, solution.solutionDetail.videoUrl, queryProblem.gymName,
-                                  queryProblem.sectorName, solution.solutionDetail.review, queryProblem.difficultyName,
-                                  queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
+                                  solution.id, queryProblem.gymName, queryProblem.sectorName,
+                                  queryProblem.difficultyName, queryProblem.imageUrl, solution.createdAt
                               ))
                               .from(solution)
                               .innerJoin(queryProblem)
@@ -43,10 +43,10 @@ public class SolutionQueryDslRepository {
     public void updateUploaderInfo(final UUID uploaderId, final String nickName,
         final String instagramId) {
         jpaQueryFactory.update(solution)
-                      .set(solution.uploaderDetail.uploader, nickName)
-                      .set(solution.uploaderDetail.instagramId, instagramId)
-                      .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
-                      .execute();
+                       .set(solution.uploaderDetail.uploader, nickName)
+                       .set(solution.uploaderDetail.instagramId, instagramId)
+                       .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
+                       .execute();
     }
 
     public DetailSolutionDto findDetailSolutionById(final Long solutionId) {

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -39,4 +39,13 @@ public class SolutionQueryDslRepository {
                               .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
                               .fetch();
     }
+
+    public void updateUploaderInfo(final UUID uploaderId, final String nickName,
+        final String instagramId) {
+        jpaQueryFactory.update(solution)
+                      .set(solution.uploaderDetail.uploader, nickName)
+                      .set(solution.uploaderDetail.instagramId, instagramId)
+                      .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
+                      .execute();
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -28,8 +28,9 @@ public class SolutionQueryDslRepository {
 
     public List<MySolutionDto> findByUploaderId(final UUID uploaderId) {
         return jpaQueryFactory.select(Projections.constructor(MySolutionDto.class,
-                                  queryProblem.gymName, queryProblem.sectorName, queryProblem.difficultyName,
-                                  queryProblem.id, solution.id, solution.createdAt
+                                  solution.id, solution.solutionDetail.videoUrl, queryProblem.gymName,
+                                  queryProblem.sectorName, solution.solutionDetail.review, queryProblem.difficultyName,
+                                  queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
                               ))
                               .from(solution)
                               .innerJoin(queryProblem)

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -1,8 +1,11 @@
 package com.first.flash.climbing.solution.infrastructure;
 
+import static com.first.flash.climbing.problem.domain.QQueryProblem.queryProblem;
 import static com.first.flash.climbing.solution.domain.QSolution.solution;
 
 import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.UUID;
@@ -21,5 +24,18 @@ public class SolutionQueryDslRepository {
                               .where(solution.problemId.eq(problemId)
                                                        .and(solution.uploaderDetail.uploaderId
                                                            .notIn(memberIds))).fetch();
+    }
+
+    public List<MySolutionDto> findByUploaderId(final UUID uploaderId) {
+        return jpaQueryFactory.select(Projections.constructor(MySolutionDto.class,
+                                  queryProblem.gymName, queryProblem.sectorName, queryProblem.difficultyName,
+                                  queryProblem.id, solution.id, solution.createdAt
+                              ))
+                              .from(solution)
+                              .innerJoin(queryProblem)
+                              .on(solution.problemId.eq(queryProblem.id))
+                              .fetchJoin()
+                              .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
+                              .fetch();
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.solution.infrastructure;
 
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
+import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -36,8 +37,8 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     }
 
     @Override
-    public List<Solution> findAllByUploaderId(final UUID uploaderId) {
-        return solutionJpaRepository.findByUploaderDetail_UploaderId(uploaderId);
+    public List<MySolutionDto> findAllByUploaderId(final UUID uploaderId) {
+        return solutionQueryDslRepository.findByUploaderId(uploaderId);
     }
 
     @Override

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.solution.infrastructure;
 
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
+import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
 import java.util.List;
 import java.util.Optional;
@@ -50,5 +51,10 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     public void updateUploaderInfo(final UUID uploaderId, final String nickName,
         final String instagramId) {
         solutionQueryDslRepository.updateUploaderInfo(uploaderId, nickName, instagramId);
+    }
+
+    @Override
+    public DetailSolutionDto findDetailSolutionById(final Long solutionId) {
+        return solutionQueryDslRepository.findDetailSolutionById(solutionId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -45,4 +45,10 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     public void deleteById(final Long id) {
         solutionJpaRepository.deleteById(id);
     }
+
+    @Override
+    public void updateUploaderInfo(final UUID uploaderId, final String nickName,
+        final String instagramId) {
+        solutionQueryDslRepository.updateUploaderInfo(uploaderId, nickName, instagramId);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
@@ -1,0 +1,10 @@
+package com.first.flash.climbing.solution.infrastructure.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record DetailSolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
+                                String review, String difficultyName, LocalDate removalDate,
+                                LocalDate settingDate, LocalDateTime uploadedAt) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
@@ -1,0 +1,9 @@
+package com.first.flash.climbing.solution.infrastructure.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record MySolutionDto(String gymName, String sectorName, String difficultyName,
+                            UUID problemId, Long solutionId, LocalDateTime uploadedAt) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
@@ -1,10 +1,9 @@
 package com.first.flash.climbing.solution.infrastructure.dto;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-public record MySolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
-                            String review, String difficultyName, LocalDate removalDate,
-                            LocalDate settingDate, LocalDateTime uploadedAt) {
+public record MySolutionDto(Long solutionId, String gymName, String sectorName,
+                            String difficultyName, String problemImageUrl,
+                            LocalDateTime uploadedAt) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
@@ -1,9 +1,10 @@
 package com.first.flash.climbing.solution.infrastructure.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record MySolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
-                            String review, String difficultyName, LocalDateTime removalDate,
-                            LocalDateTime settingDate, LocalDateTime uploadedAt) {
+                            String review, String difficultyName, LocalDate removalDate,
+                            LocalDate settingDate, LocalDateTime uploadedAt) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
@@ -1,9 +1,9 @@
 package com.first.flash.climbing.solution.infrastructure.dto;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
-public record MySolutionDto(String gymName, String sectorName, String difficultyName,
-                            UUID problemId, Long solutionId, LocalDateTime uploadedAt) {
+public record MySolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
+                            String review, String difficultyName, LocalDateTime removalDate,
+                            LocalDateTime settingDate, LocalDateTime uploadedAt) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.solution.ui;
 
 import com.first.flash.climbing.solution.application.SolutionSaveService;
 import com.first.flash.climbing.solution.application.SolutionService;
+import com.first.flash.climbing.solution.application.dto.MySolutionsResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
@@ -39,11 +40,11 @@ public class SolutionController {
     @Operation(summary = "해설 조회", description = "본인이 등록한 해설 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공적으로 해설을 조회함",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionsResponseDto.class)))
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MySolutionsResponseDto.class)))
     })
     @GetMapping("solutions")
-    public ResponseEntity<SolutionsResponseDto> getMySolutions() {
-        SolutionsResponseDto response = solutionService.findMySolutions();
+    public ResponseEntity<MySolutionsResponseDto> getMySolutions() {
+        MySolutionsResponseDto response = solutionService.findMySolutions();
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -55,7 +55,8 @@ public class SolutionController {
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = DetailSolutionDto.class)))
     })
     @GetMapping("solutions/{solutionId}")
-    public ResponseEntity<DetailSolutionDto> getDetailSolution(@PathVariable final Long solutionId) {
+    public ResponseEntity<DetailSolutionDto> getDetailSolution(
+        @PathVariable final Long solutionId) {
         DetailSolutionDto response = solutionService.findDetailSolutionById(solutionId);
         return ResponseEntity.ok(response);
     }
@@ -117,11 +118,9 @@ public class SolutionController {
                 @ExampleObject(name = "해설 없음", value = "{\"error\": \"아이디가 1인 해설을 찾을 수 없습니다.\"}")
             }))
     })
-    @PatchMapping("problems/{problemId}/solutions/{solutionId}")
-    public ResponseEntity<SolutionResponseDto> updateSolution(@PathVariable final UUID problemId,
-        @PathVariable Long solutionId,
+    @PatchMapping("/solutions/{solutionId}")
+    public ResponseEntity<SolutionResponseDto> updateSolution(@PathVariable Long solutionId,
         @Valid @RequestBody final SolutionUpdateRequestDto solutionUpdateRequestDto) {
-
         return ResponseEntity.status(HttpStatus.OK)
                              .body(
                                  solutionService.updateContent(solutionId, solutionUpdateRequestDto)
@@ -142,12 +141,9 @@ public class SolutionController {
                 @ExampleObject(name = "해설 없음", value = "{\"error\": \"아이디가 1인 해설을 찾을 수 없습니다.\"}")
             }))
     })
-    @DeleteMapping("problems/{problemId}/solutions/{solutionId}")
-    public ResponseEntity<Void> deleteSolution(@PathVariable final UUID problemId,
-        @PathVariable Long solutionId) {
-
-        solutionService.deleteSolution(solutionId, problemId);
-
+    @DeleteMapping("/solutions/{solutionId}")
+    public ResponseEntity<Void> deleteSolution(@PathVariable Long solutionId) {
+        solutionService.deleteSolution(solutionId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -7,6 +7,7 @@ import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
+import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -46,6 +47,12 @@ public class SolutionController {
     public ResponseEntity<MySolutionsResponseDto> getMySolutions() {
         MySolutionsResponseDto response = solutionService.findMySolutions();
 
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("solutions/{solutionId}")
+    public ResponseEntity<DetailSolutionDto> getSolution(@PathVariable final Long solutionId) {
+        DetailSolutionDto response = solutionService.findDetailSolutionById(solutionId);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -46,12 +46,16 @@ public class SolutionController {
     @GetMapping("solutions")
     public ResponseEntity<MySolutionsResponseDto> getMySolutions() {
         MySolutionsResponseDto response = solutionService.findMySolutions();
-
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "해설 디테일 조회", description = "해설 id로 상세 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 해설 디테일을 조회함",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DetailSolutionDto.class)))
+    })
     @GetMapping("solutions/{solutionId}")
-    public ResponseEntity<DetailSolutionDto> getSolution(@PathVariable final Long solutionId) {
+    public ResponseEntity<DetailSolutionDto> getDetailSolution(@PathVariable final Long solutionId) {
         DetailSolutionDto response = solutionService.findDetailSolutionById(solutionId);
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
## 요약
본인이 업로드한 해설 조회와 특정 해설에 대한 상세 정보를 조회할 수 있도록 구현헀습니다.

## 내용
### 본인이 업로드한 해설 조회
![image](https://github.com/user-attachments/assets/4f639d75-55f8-4ba4-9b6e-33e480d9affd)
본인이 업로드한 해설들을 조회할 때 필요한 데이터들은 다음과 같습니다.
- 해설 id
- 클라이밍장명
- 섹터명
- 업로드 일자
- 문제 사진
- 난이도 이름
해설 id가 필요한 이유는 위 그리드를 누르면 해당 해설의 상세 정보를 조회할 수 있어야 하기 때문입니다.

클라이밍장명, 섹터명 등 문제 상세 정보에 포함된 데이터를 함께 반환하기 위해 문제 조회 모델과 join을 했습니다.
```java
    public List<MySolutionDto> findByUploaderId(final UUID uploaderId) {
        return jpaQueryFactory.select(Projections.constructor(MySolutionDto.class,
                                  solution.id, queryProblem.gymName, queryProblem.sectorName,
                                  queryProblem.difficultyName, queryProblem.imageUrl, solution.createdAt
                              ))
                              .from(solution)
                              .innerJoin(queryProblem)
                              .on(solution.problemId.eq(queryProblem.id))
                              .fetchJoin()
                              .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
                              .fetch();
    }
```

---

### 해설 영상 상세 정보 조회
![image](https://github.com/user-attachments/assets/e8b5409d-8d49-4dc2-8a29-108ba2a7ff32)
본인이 업로드한 해설들을 조회할 때 필요한 데이터들은 사진에 나온 데이터들입니다. 여기서도 수정과 삭제를 할 수 있어야 하므로, 해설의 id가 필요합니다.

본인이 업로드한 해설 조회를 구현할 때와 마찬가지로 문제 조회 모델과 join을 했습니다.
```java
    public DetailSolutionDto findDetailSolutionById(final Long solutionId) {
        return jpaQueryFactory.select(Projections.constructor(DetailSolutionDto.class,
                                  solution.id, solution.solutionDetail.videoUrl, queryProblem.gymName,
                                  queryProblem.sectorName, solution.solutionDetail.review, queryProblem.difficultyName,
                                  queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
                              ))
                              .from(solution)
                              .innerJoin(queryProblem)
                              .on(solution.problemId.eq(queryProblem.id))
                              .where(solution.id.eq(solutionId))
                              .fetchJoin()
                              .fetchOne();
    }
```

---

### member 정보 수정으로 인한 solution vo값 수정을 벌크 연산으로 변경
기존에 Service 객체에서 member id로 solution을 조회할 때 반환되는 것은 Solution 객체였습니다. 하지만 위에 작업 내용에 따라 마이페이지에 필요한 데이터들을 담은 dto로 변경되었습니다.
때문에 member의 정보 수정을 반영하는 로직을 수정해야 했고, 방법은 다음과 같습니다.
1. member id로 solution을 반환하는 메서드를 추가로 만드는 방법
2. 벌크 연산으로 수정하는 방법

데이터가 많아질 수록 본인이 업로드한 해설을 모두 API 서버로 가져와 수정하는 것보다 DB에 수정 요청을 보내는 것이 더 안정적이고 빠를 것이라고 판단해 벌크 연산을 택했습니다. 다른 의견이 있으시다면 말씀해주세요!

---

## 논의가 필요한 부분
해설을 수정, 삭제하는 데 있어서 problemId가 필수적으로 필요한지 논의해봐야할 것 같습니다!
제 생각으로는 계층 구조이긴 하지만, 마이페이지와 마찬가지로 solution을 독립적으로 다루는 경우가 있으니 다음과 같이 해도 될 것 같습니다..!
`/solutions/{solutionId}`

