### PR TITLE
admin 기능에 prefix 추가

### DIFF
--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -32,7 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "gyms", description = "클라이밍장 조회 API")
 @RestController
-@RequestMapping("/gyms")
 @RequiredArgsConstructor
 public class ClimbingGymController {
 
@@ -57,7 +56,7 @@ public class ClimbingGymController {
                         ]
                     """))),
     })
-    @GetMapping
+    @GetMapping("/gyms")
     public List<ClimbingGymResponseDto> getGyms() {
         return climbingGymService.findAllClimbingGyms().stream()
                                  .toList();
@@ -74,7 +73,7 @@ public class ClimbingGymController {
                 @ExampleObject(name = "난이도 레벨 중복", value = "{\"error\": \"난이도 레벨이 중복되었습니다: 2\"}"),
             })),
     })
-    @PostMapping
+    @PostMapping("/admin/gyms")
     public ResponseEntity<ClimbingGymCreateResponseDto> createGym(
         @Valid @RequestBody final ClimbingGymCreateRequestDto gymCreateRequestDto) {
 

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -52,7 +52,7 @@ public class ProblemController {
                 @ExampleObject(name = "난이도 없음", value = "{\"error\": \"이름이 핑크인 난이도를 찾을 수 없습니다.\"}")
             }))
     })
-    @PostMapping("/gyms/{gymId}/sectors/{sectorId}/problems")
+    @PostMapping("admin/gyms/{gymId}/sectors/{sectorId}/problems")
     public ResponseEntity<ProblemCreateResponseDto> saveProblems(
         @PathVariable("gymId") final Long gymId,
         @PathVariable("sectorId") final Long sectorId,

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -52,7 +52,7 @@ public class ProblemController {
                 @ExampleObject(name = "난이도 없음", value = "{\"error\": \"이름이 핑크인 난이도를 찾을 수 없습니다.\"}")
             }))
     })
-    @PostMapping("admin/gyms/{gymId}/sectors/{sectorId}/problems")
+    @PostMapping("/admin/gyms/{gymId}/sectors/{sectorId}/problems")
     public ResponseEntity<ProblemCreateResponseDto> saveProblems(
         @PathVariable("gymId") final Long gymId,
         @PathVariable("sectorId") final Long sectorId,

--- a/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
+++ b/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
@@ -58,7 +58,7 @@ public class SectorController {
                 @ExampleObject(name = "클라이밍장 없음", value = "{\"error\": \"아이디가 1인 클라이밍장을 찾을 수 없습니다.\"}")
             }))
     })
-    @PostMapping("gyms/{gymId}/sectors")
+    @PostMapping("admin/gyms/{gymId}/sectors")
     public ResponseEntity<SectorDetailResponseDto> createSector(@PathVariable final Long gymId,
         @Valid @RequestBody final SectorCreateRequestDto sectorCreateRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -79,7 +79,7 @@ public class SectorController {
                 @ExampleObject(name = "섹터 없음", value = "{\"error\": \"아이디가 1인 섹터를 찾을 수 없습니다.\"}")
             }))
     })
-    @PatchMapping("sectors/{sectorId}")
+    @PatchMapping("admin/sectors/{sectorId}")
     public ResponseEntity<SectorDetailResponseDto> updateSectorRemovalDate(
         @PathVariable final Long sectorId,
         @Valid @RequestBody final SectorUpdateRemovalDateRequestDto sectorUpdateRemovalDateRequestDto) {
@@ -103,7 +103,7 @@ public class SectorController {
                 @ExampleObject(name = "클라이밍장 없음", value = "{\"error\": \"아이디가 1인 클라이밍장을 찾을 수 없습니다.\"}")
             }))
     })
-    @PutMapping("sectors/{sectorId}")
+    @PutMapping("admin/sectors/{sectorId}")
     public ResponseEntity<SectorDetailResponseDto> updateSector(
         @PathVariable final Long sectorId,
         @Valid @RequestBody final SectorUpdateRequestDto updateRequestDto) {


### PR DESCRIPTION
## 요약
아래 API에 admin prefix를 붙였습니다.
- 문제 생성 API
- 클라이밍장 생성 API
- 섹터 탈거일 수정 API
- 섹터 생성(갱신) API
- 섹터 전체 수정 API

## 내용
현재 admin prefix를 붙이면, ADMIN role을 가진 사용자만 해당 api를 쓸 수 있도록 해놨습니다.
```java
.authorizeHttpRequests(authorize -> authorize
                       .requestMatchers(AUTH_WHITELIST).permitAll()
                       .requestMatchers("/admin/**").hasRole("ADMIN")
                       .anyRequest().authenticated()
                   )
```
이를 이용해 회원이 접근해선 안 되는 API에 admin prefix를 추가했습니다.

이제 어드민 기능에 USER role을 가진 회원이 요청을 보내면 아래와 같은 응답을 받게 됩니다.
<img width="419" alt="image" src="https://github.com/user-attachments/assets/4ecc85b4-980d-4340-9beb-56b57b012a61">

## 논의할 점
- 현재 admin prefix가 붙은 API를 기존 위치에 둘 것인지, 어드민 기능을 따로 모을 것인지
- member의 role을 고려했을 때, 실제 prod 환경에서 admin 기능을 어떻게 사용할 것인지
- 다른 admin 기능이 있는지