### PR TITLE
처리되지 않는 예외를 401로 처리하는 문제 해결

### DIFF
--- a/src/main/java/com/first/flash/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/first/flash/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,31 @@
+package com.first.flash.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final String INTERNAL_SERVER_ERROR_MESSAGE = "알 수 없는 에러가 발생했습니다. 관리자에게 문의해주세요.";
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<String> handleIllegalArgumentException(
+        final IllegalArgumentException exception) {
+        log.error(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                             .body(INTERNAL_SERVER_ERROR_MESSAGE);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<String> handleHttpRequestMethodNotSupportedException(
+        final HttpRequestMethodNotSupportedException exception) {
+        log.error(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                             .body(exception.getMessage());
+    }
+}

--- a/src/main/java/com/first/flash/global/filter/JwtAuthFilter.java
+++ b/src/main/java/com/first/flash/global/filter/JwtAuthFilter.java
@@ -3,6 +3,7 @@ package com.first.flash.global.filter;
 import com.first.flash.account.auth.domain.TokenManager;
 import com.first.flash.account.auth.exception.exceptions.InvalidTokenException;
 import com.first.flash.account.auth.exception.exceptions.TokenExpiredException;
+import com.first.flash.account.member.exception.exceptions.MemberNotFoundException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -40,9 +41,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             UUID id = tokenManager.parseToken(token);
             UserDetails userDetails = userDetailsService.loadUserByUsername(id.toString());
             setAuthentication(userDetails);
-        } catch (TokenExpiredException | InvalidTokenException exception) {
+        } catch (final TokenExpiredException | InvalidTokenException |
+                       MemberNotFoundException exception) {
+            log.error(exception.getMessage());
             throw exception;
         } catch (RuntimeException exception) {
+            log.error("인증 오류: {}", exception.getMessage());
             throw new AuthenticationServiceException(exception.getMessage());
         }
         filterChain.doFilter(request, response);

--- a/src/main/java/com/first/flash/global/filter/TokenExceptionFilter.java
+++ b/src/main/java/com/first/flash/global/filter/TokenExceptionFilter.java
@@ -2,6 +2,7 @@ package com.first.flash.global.filter;
 
 import com.first.flash.account.auth.exception.exceptions.InvalidTokenException;
 import com.first.flash.account.auth.exception.exceptions.TokenExpiredException;
+import com.first.flash.account.member.exception.exceptions.MemberNotFoundException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -17,11 +18,18 @@ public class TokenExceptionFilter extends OncePerRequestFilter {
         final FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (TokenExpiredException | InvalidTokenException exception) {
-            response.setCharacterEncoding("UTF-8");
-            response.setContentType("application/json; charset=UTF-8");
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.getWriter().write(exception.getMessage());
+        } catch (final TokenExpiredException | InvalidTokenException exception) {
+            handleResponse(response, HttpServletResponse.SC_UNAUTHORIZED, exception.getMessage());
+        } catch (final MemberNotFoundException exception) {
+            handleResponse(response, HttpServletResponse.SC_NOT_FOUND, exception.getMessage());
         }
+    }
+
+    private static void handleResponse(final HttpServletResponse response, final int scNotFound,
+        final String exception) throws IOException {
+        response.setCharacterEncoding("UTF-8");
+        response.setContentType("application/json; charset=UTF-8");
+        response.setStatus(scNotFound);
+        response.getWriter().write(exception);
     }
 }


### PR DESCRIPTION
## 요약
어떤 예외가 발생해도 아래 메세지와 함께 401 에러가 뜨는 현상을 발견했습니다.
`full authentication is required to access this resource`

이는 Spring Security에 의해 처리되지 않는 예외를 401로 처리하기 때문이었습니다.
때문에 현재 처리되지 않았던 IllegalArgumentException, HttpRequestMethodNotSupportedException, filter에서의 MemberNotFoundException를 정상적으로 처리하는 로직을 작성했습니다.

## 내용
### Filter에서의 MemberNotFoundException
인증 작업 중 발생하는 MemberNotFoundException는 기존 ExceptionHandler에서 잡히지 않아 따로 처리해줘야하므로 TokenExceptionFIlter에서 처리해줬습니다.
```java
@Override
    protected void doFilterInternal(final HttpServletRequest request,
        final HttpServletResponse response,
        final FilterChain filterChain) throws ServletException, IOException {
        try {
            filterChain.doFilter(request, response);
        } catch (final TokenExpiredException | InvalidTokenException exception) {
            handleResponse(response, HttpServletResponse.SC_UNAUTHORIZED, exception.getMessage());
        } catch (final MemberNotFoundException exception) {
            handleResponse(response, HttpServletResponse.SC_NOT_FOUND, exception.getMessage());
        }
    }
```

### 공통적으로 발생할 수 있는 예외 처리
여러 곳에서 발생할 수 있는 예외를 GlobalExceptionHandler에서 처리할 수 있도록 했습니다.
```java
@Slf4j
@RestControllerAdvice
public class GlobalExceptionHandler {

    private static final String INTERNAL_SERVER_ERROR_MESSAGE = "알 수 없는 에러가 발생했습니다. 관리자에게 문의해주세요.";

    @ExceptionHandler(IllegalArgumentException.class)
    public ResponseEntity<String> handleIllegalArgumentException(
        final IllegalArgumentException exception) {
        log.error(exception.getMessage());
        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
                             .body(INTERNAL_SERVER_ERROR_MESSAGE);
    }

    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
    public ResponseEntity<String> handleHttpRequestMethodNotSupportedException(
        final HttpRequestMethodNotSupportedException exception) {
        log.error(exception.getMessage());
        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
                             .body(exception.getMessage());
    }
}
```