### PR TITLE
회원 탈퇴 시 해당 유저가 업로드한 해설을 모두 삭제하는 기능 추가

### DIFF
--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionEventHandler.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.application;
 
+import com.first.flash.account.member.domain.MemberDeletedEvent;
 import com.first.flash.account.member.domain.MemberInfoUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
@@ -11,11 +12,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class SolutionEventHandler {
 
     private final SolutionSaveService solutionSaveService;
+    private final SolutionService solutionService;
 
     @EventListener
     @Transactional
     public void updateSolutionInfo(final MemberInfoUpdatedEvent event) {
         solutionSaveService.updateUploaderInfo(event.getMemberId(), event.getNickName(),
             event.getInstagramId());
+    }
+
+    @EventListener
+    @Transactional
+    public void deleteSolution(final MemberDeletedEvent event) {
+        solutionService.deleteByUploaderId(event.getMemberId());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -85,6 +85,11 @@ public class SolutionService {
         Events.raise(SolutionDeletedEvent.of(solution.getProblemId()));
     }
 
+    @Transactional
+    public void deleteByUploaderId(final UUID memberId) {
+        solutionRepository.deleteByUploaderId(memberId);
+    }
+
     private void validateUploader(final UUID uploaderId) {
         if (!AuthUtil.isSameId(uploaderId)) {
             throw new SolutionAccessDeniedException();

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -21,4 +21,6 @@ public interface SolutionRepository {
     void updateUploaderInfo(final UUID uploaderId, final String nickName, final String instagramId);
 
     DetailSolutionDto findDetailSolutionById(final Long solutionId);
+
+    void deleteByUploaderId(final UUID memberId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionJpaRepository.java
@@ -17,4 +17,6 @@ public interface SolutionJpaRepository extends JpaRepository<Solution, Long> {
     List<Solution> findByUploaderDetail_UploaderId(final UUID uploaderId);
 
     void deleteById(final Long id);
+
+    void deleteByUploaderDetail_UploaderId(final UUID memberId);
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -57,4 +57,9 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     public DetailSolutionDto findDetailSolutionById(final Long solutionId) {
         return solutionQueryDslRepository.findDetailSolutionById(solutionId);
     }
+
+    @Override
+    public void deleteByUploaderId(final UUID memberId) {
+        solutionJpaRepository.deleteByUploaderDetail_UploaderId(memberId);
+    }
 }


### PR DESCRIPTION
## 요약
회원 탈퇴 시 이벤트를 수신해 해당 유저의 해설을 모두 삭제하는 기능 구현

## 내용
MemberDeletedEvent를 SolutionEventHandler에서 수신
```java
@EventListener
@Transactional
public void deleteSolution(final MemberDeletedEvent event) {
        solutionService.deleteByUploaderId(event.getMemberId());
     }
```
spring-data-jpa를 이용해 탈퇴한 회원이 업로드한 해설 영상을 모두 삭제
```java
public interface SolutionJpaRepository extends JpaRepository<Solution, Long> {
    ...
    void deleteByUploaderDetail_UploaderId(final UUID memberId);
}
```