### PR TITLE
해설 정보 제공 시 업로드한 사용자의 프로필 url 추가

### DIFF
--- a/src/main/java/com/first/flash/account/member/application/MemberService.java
+++ b/src/main/java/com/first/flash/account/member/application/MemberService.java
@@ -6,8 +6,8 @@ import com.first.flash.account.member.application.dto.MemberCompleteRegistration
 import com.first.flash.account.member.application.dto.MemberCompleteRegistrationResponse;
 import com.first.flash.account.member.application.dto.MemberInfoResponse;
 import com.first.flash.account.member.domain.Member;
-import com.first.flash.account.member.domain.MemberInfoUpdatedEvent;
 import com.first.flash.account.member.domain.MemberDeletedEvent;
+import com.first.flash.account.member.domain.MemberInfoUpdatedEvent;
 import com.first.flash.account.member.domain.MemberRepository;
 import com.first.flash.account.member.exception.exceptions.MemberNotFoundException;
 import com.first.flash.account.member.exception.exceptions.NickNameDuplicatedException;
@@ -47,7 +47,7 @@ public class MemberService {
             request.gender(), request.reach(), request.profileImageUrl());
 
         Events.raise(MemberInfoUpdatedEvent.of(member.getId(), member.getNickName(),
-            member.getInstagramId()));
+            member.getInstagramId(), member.getProfileImageUrl()));
 
         return MemberCompleteRegistrationResponse.toDto(member);
     }

--- a/src/main/java/com/first/flash/account/member/domain/MemberInfoUpdatedEvent.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberInfoUpdatedEvent.java
@@ -12,9 +12,10 @@ public class MemberInfoUpdatedEvent extends Event {
     private final UUID memberId;
     private final String nickName;
     private final String instagramId;
+    private final String profileImageUrl;
 
     public static MemberInfoUpdatedEvent of(final UUID memberId, final String nickName,
-        final String instagramId) {
-        return new MemberInfoUpdatedEvent(memberId, nickName, instagramId);
+        final String instagramId, final String profileImageUrl) {
+        return new MemberInfoUpdatedEvent(memberId, nickName, instagramId, profileImageUrl);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionEventHandler.java
@@ -18,7 +18,7 @@ public class SolutionEventHandler {
     @Transactional
     public void updateSolutionInfo(final MemberInfoUpdatedEvent event) {
         solutionSaveService.updateUploaderInfo(event.getMemberId(), event.getNickName(),
-            event.getInstagramId());
+            event.getInstagramId(), event.getProfileImageUrl());
     }
 
     @EventListener

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -29,7 +29,8 @@ public class SolutionSaveService {
         Member member = memberService.findById(id);
 
         Solution solution = Solution.of(member.getNickName(), createRequestDto.review(),
-            member.getInstagramId(), createRequestDto.videoUrl(), problemId, member.getId());
+            member.getInstagramId(), createRequestDto.videoUrl(), problemId, member.getId(),
+            member.getProfileImageUrl());
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
         return SolutionResponseDto.toDto(savedSolution);
@@ -37,7 +38,7 @@ public class SolutionSaveService {
 
     @Transactional
     public void updateUploaderInfo(final UUID uploaderId, final String nickName,
-        final String instagramId) {
-        solutionRepository.updateUploaderInfo(uploaderId, nickName, instagramId);
+        final String instagramId, final String profileImageUrl) {
+        solutionRepository.updateUploaderInfo(uploaderId, nickName, instagramId, profileImageUrl);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionResponseDto.java
@@ -7,7 +7,8 @@ import com.first.flash.global.util.AuthUtil;
 import java.util.UUID;
 
 public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
-                                  String videoUrl, UUID uploaderId, Boolean isUploader) {
+                                  String videoUrl, UUID uploaderId, Boolean isUploader,
+                                  String profileImageUrl) {
 
     public static SolutionResponseDto toDto(final Solution solution) {
         SolutionDetail solutionDetail = solution.getSolutionDetail();
@@ -18,6 +19,7 @@ public record SolutionResponseDto(Long id, String uploader, String review, Strin
 
         return new SolutionResponseDto(solution.getId(), uploaderDetail.getUploader(),
             solutionDetail.getReview(), uploaderDetail.getInstagramId(),
-            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId(), isUploader);
+            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId(), isUploader,
+            uploaderDetail.getProfileImageUrl());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -33,25 +33,28 @@ public class Solution extends BaseEntity {
     private Long optionalWeight;
 
     protected Solution(final String uploader, final String review, final String instagramId,
-        final String videoUrl, final UUID problemId, final UUID uploaderId) {
+        final String videoUrl, final UUID problemId, final UUID uploaderId,
+        final String profileImageUrl) {
 
         this.solutionDetail = SolutionDetail.of(review, videoUrl);
-        this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId);
+        this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId, profileImageUrl);
         this.optionalWeight = DEFAULT_OPTIONAL_WEIGHT;
         this.problemId = problemId;
     }
 
     public static Solution of(final String uploader, final String review, final String instagramId,
-        final String videoUrl,
-        final UUID problemId, final UUID uploaderId) {
+        final String videoUrl, final UUID problemId, final UUID uploaderId,
+        final String profileImageUrl) {
 
-        return new Solution(uploader, review, instagramId, videoUrl, problemId, uploaderId);
+        return new Solution(uploader, review, instagramId, videoUrl, problemId, uploaderId,
+            profileImageUrl);
     }
 
-    public void updateUploaderInfo(final String uploader, final String instagramId) {
+    public void updateUploaderInfo(final String uploader, final String instagramId,
+        final String profileImageUrl) {
         UUID uploaderId = this.uploaderDetail.getUploaderId();
 
-        this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId);
+        this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId, profileImageUrl);
     }
 
     public void updateContentInfo(final String review, final String videoUrl) {

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -18,7 +18,8 @@ public interface SolutionRepository {
 
     void deleteById(final Long id);
 
-    void updateUploaderInfo(final UUID uploaderId, final String nickName, final String instagramId);
+    void updateUploaderInfo(final UUID uploaderId, final String nickName, final String instagramId,
+        final String profileImageUrl);
 
     DetailSolutionDto findDetailSolutionById(final Long solutionId);
 

--- a/src/main/java/com/first/flash/climbing/solution/domain/vo/UploaderDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/vo/UploaderDetail.java
@@ -19,16 +19,18 @@ public class UploaderDetail {
     private UUID uploaderId;
     private String uploader;
     private String instagramId;
+    private String profileImageUrl;
 
     protected UploaderDetail(final UUID uploaderId, final String uploader,
-        final String instagramId) {
+        final String instagramId, final String profileImageUrl) {
         this.uploaderId = uploaderId;
         this.uploader = uploader;
         this.instagramId = instagramId;
+        this.profileImageUrl = profileImageUrl;
     }
 
     public static UploaderDetail of(final UUID uploaderId, final String uploader,
-        final String instagramId) {
-        return new UploaderDetail(uploaderId, uploader, instagramId);
+        final String instagramId, final String profileImageUrl) {
+        return new UploaderDetail(uploaderId, uploader, instagramId, profileImageUrl);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -41,10 +41,11 @@ public class SolutionQueryDslRepository {
     }
 
     public void updateUploaderInfo(final UUID uploaderId, final String nickName,
-        final String instagramId) {
+        final String instagramId, final String profileImageUrl) {
         jpaQueryFactory.update(solution)
                        .set(solution.uploaderDetail.uploader, nickName)
                        .set(solution.uploaderDetail.instagramId, instagramId)
+                       .set(solution.uploaderDetail.profileImageUrl, profileImageUrl)
                        .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
                        .execute();
     }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -49,8 +49,9 @@ public class SolutionRepositoryImpl implements SolutionRepository {
 
     @Override
     public void updateUploaderInfo(final UUID uploaderId, final String nickName,
-        final String instagramId) {
-        solutionQueryDslRepository.updateUploaderInfo(uploaderId, nickName, instagramId);
+        final String instagramId, final String profileImageUrl) {
+        solutionQueryDslRepository.updateUploaderInfo(uploaderId, nickName, instagramId,
+            profileImageUrl);
     }
 
     @Override


### PR DESCRIPTION
# 요약
![image](https://github.com/user-attachments/assets/5d9e7c61-e712-479c-ad0c-b6f3b9bcb7e4)

해설 정보 제공 시 업로드한 사용자의 프로필 url 주소가 필요하여 해당 필드를 추가하였습니다.

# 내용

## Solution Entity에 profileImageUrl 필드 추가

- 프로필 이미지 url을 제공하기 위한 방법으로 다음 두 가지를 고려하였습니다.
  - `Solution` Entity에 필드를 추가
  - `Member` ID를 이용하여 Join
- 업로드한 사용자의 이름, 인스타그램 ID 등이 이미 `Solution` Entity에 존재하여 프로필 이미지 url도 `Solution` Entity에 위치하는 것이 자연스럽다고 판단하였습니다.

## 구현

```java
public class UploaderDetail {

    @Column(columnDefinition = "BINARY(16)")
    private UUID uploaderId;
    private String uploader;
    private String instagramId;
    private String profileImageUrl;

    protected UploaderDetail(final UUID uploaderId, final String uploader,
        final String instagramId, final String profileImageUrl) {
        this.uploaderId = uploaderId;
        this.uploader = uploader;
        this.instagramId = instagramId;
        this.profileImageUrl = profileImageUrl;
    }

    public static UploaderDetail of(final UUID uploaderId, final String uploader,
        final String instagramId, final String profileImageUrl) {
        return new UploaderDetail(uploaderId, uploader, instagramId, profileImageUrl);
    }
}
```

- `Solution` Entity의 VO인 `UploaderDetail`에 profileImageUrl 필드를 추가하였습니다.

### 변경 사항

- `GET /problems/{problemId}/solutions` 응답으로 제공되는 해설 목록에 profileImageUrl 필드 추가
![image](https://github.com/user-attachments/assets/8154c19f-0417-4786-b763-4957347ad112)

- `Member` 정보 수정 시 `Solution`의 profileImageUrl도 함께 수정되도록 이벤트 처리 항목 추가