### PR TITLE
GET 요청만 가능한 WEB Role 추가

### DIFF
--- a/src/main/java/com/first/flash/account/member/domain/Role.java
+++ b/src/main/java/com/first/flash/account/member/domain/Role.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 @ToString
 public enum Role {
 
-    ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER");
+    ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER"), ROLE_WEB("ROLE_WEB");
 
     private String role;
 }

--- a/src/main/java/com/first/flash/global/config/SecurityConfig.java
+++ b/src/main/java/com/first/flash/global/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.first.flash.global.filter.JwtAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -47,7 +48,9 @@ public class SecurityConfig {
                    .authorizeHttpRequests(authorize -> authorize
                        .requestMatchers(AUTH_WHITELIST).permitAll()
                        .requestMatchers("/admin/**").hasRole("ADMIN")
-                       .anyRequest().authenticated()
+                       .requestMatchers(HttpMethod.GET, "/**").hasRole("WEB")
+                       .requestMatchers("/**").hasAnyRole("ADMIN", "USER")
+                       .anyRequest().denyAll()
                    )
                    .addFilterBefore(new JwtAuthFilter(tokenManager, userDetailsService),
                        UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## 요약
현재 제공되고 있는 웹 서비스의 지속을 위해 WEB role을 추가했습니다.

## 내용
### 권한 정리
1. ADMIN 역할:
- /admin/**: 접근 가능 (모든 HTTP 메서드)
- / 아래 모든 경로: GET, POST, PUT, DELETE 등 모든 HTTP 메서드 접근 가능
- 특별히 GET 요청만 허용된 규칙에 영향을 받지 않음.
2. USER 역할:
- /admin/**: 접근 불가
- / 아래 모든 경로: GET, POST, PUT, DELETE 등 모든 HTTP 메서드 접근 가능
- 특별히 GET 요청만 허용된 규칙에 영향을 받지 않음.
3. WEB 역할:
- GET 요청만 허용됨.
- 다른 HTTP 메서드(POST, PUT, DELETE 등)는 접근 불가.
- 예를 들어, GET 요청에 대해서는 모든 경로에 접근 가능하지만, POST/PUT/DELETE 요청은 접근할 수 없음.