### PR TITLE
모든 역할 권한 막히는 문제 해결

### DIFF
--- a/src/main/java/com/first/flash/global/config/SecurityConfig.java
+++ b/src/main/java/com/first/flash/global/config/SecurityConfig.java
@@ -48,9 +48,9 @@ public class SecurityConfig {
                    .authorizeHttpRequests(authorize -> authorize
                        .requestMatchers(AUTH_WHITELIST).permitAll()
                        .requestMatchers("/admin/**").hasRole("ADMIN")
-                       .requestMatchers(HttpMethod.GET, "/**").hasRole("WEB")
+                       .requestMatchers(HttpMethod.GET, "/**").hasAnyRole("ADMIN", "USER", "WEB")
                        .requestMatchers("/**").hasAnyRole("ADMIN", "USER")
-                       .anyRequest().denyAll()
+                       .anyRequest().authenticated()
                    )
                    .addFilterBefore(new JwtAuthFilter(tokenManager, userDetailsService),
                        UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
순차적으로 권한 검사가 이뤄지기 때문에 아래와 같은 순서대로 작성했습니다.
1. /admin/** 경로는 ADMIN ROLE을 가진 회원에게만 허용
```java
.requestMatchers("/admin/**").hasRole("ADMIN")
```
2. 모든 경로의 GET 요청은 모든 유저에게 허용
```java
.requestMatchers(HttpMethod.GET, "/**").hasAnyRole("ADMIN", "USER", "WEB")
```
3. /admin/** 제외 모든 경로의 모든 메서드에 대해 ADMIN, USER ROLE 회원에게 허용
```java
.requestMatchers("/**").hasAnyRole("ADMIN", "USER")
```