### PR TITLE
마케팅 수신 동의 여부 추가

### DIFF
--- a/src/main/java/com/first/flash/account/auth/application/dto/LoginRequestDto.java
+++ b/src/main/java/com/first/flash/account/auth/application/dto/LoginRequestDto.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public record LoginRequestDto(@NotEmpty(message = "토큰은 필수입니다.") String token,
-                              @NotNull(message = "플랫폼은 필수입니다.") @ValidEnum(enumClass = Provider.class) Provider provider) {
+                              @NotNull(message = "플랫폼은 필수입니다.") @ValidEnum(enumClass = Provider.class) Provider provider,
+                              Boolean hasAgreedToMarketing) {
 
 }

--- a/src/main/java/com/first/flash/account/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/com/first/flash/account/auth/exception/AuthExceptionHandler.java
@@ -2,6 +2,7 @@ package com.first.flash.account.auth.exception;
 
 import com.first.flash.account.auth.exception.exceptions.InvalidAppleKeyException;
 import com.first.flash.account.auth.exception.exceptions.InvalidTokenException;
+import com.first.flash.account.auth.exception.exceptions.MarketingConsentRequiredException;
 import com.first.flash.account.auth.exception.exceptions.SocialRequestFailedException;
 import com.first.flash.account.auth.exception.exceptions.TokenExpiredException;
 import org.springframework.http.HttpStatus;
@@ -33,6 +34,12 @@ public class AuthExceptionHandler {
     @ExceptionHandler
     public ResponseEntity<String> handleTokenExpiredException(
         final TokenExpiredException exception) {
+        return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleMarketingConsentRequiredException(
+        final MarketingConsentRequiredException exception) {
         return getResponseWithStatus(HttpStatus.BAD_REQUEST, exception);
     }
 

--- a/src/main/java/com/first/flash/account/auth/exception/exceptions/MarketingConsentRequiredException.java
+++ b/src/main/java/com/first/flash/account/auth/exception/exceptions/MarketingConsentRequiredException.java
@@ -1,0 +1,8 @@
+package com.first.flash.account.auth.exception.exceptions;
+
+public class MarketingConsentRequiredException extends RuntimeException{
+
+    public MarketingConsentRequiredException() {
+        super("회원가입 시 마케팅 수신 동의 여부를 선택해야 합니다.");
+    }
+}

--- a/src/main/java/com/first/flash/account/member/domain/Member.java
+++ b/src/main/java/com/first/flash/account/member/domain/Member.java
@@ -29,6 +29,7 @@ public class Member {
     private Double height;
     private Double reach;
     private String profileImageUrl;
+    private Boolean hasAgreedToMarketing;
     @Enumerated(EnumType.STRING)
     private Gender gender;
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/first/flash/account/member/domain/Member.java
+++ b/src/main/java/com/first/flash/account/member/domain/Member.java
@@ -34,23 +34,6 @@ public class Member {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    public static Member of(final UUID id, final String email, final String nickName,
-        final String instagramId, final Double height, final Double reach,
-        final String profileImageUrl, final Gender gender, final String socialId) {
-        return Member.builder()
-                     .id(id)
-                     .email(email)
-                     .nickName(nickName)
-                     .socialId(socialId)
-                     .instagramId(instagramId)
-                     .height(height)
-                     .reach(reach)
-                     .profileImageUrl(profileImageUrl)
-                     .gender(gender)
-                     .role(Role.ROLE_USER)
-                     .build();
-    }
-
     public void completeRegistration(final String nickName, final String instagramId,
         final Double height, final Gender gender, final Double reach,
         final String profileImageUrl) {


### PR DESCRIPTION
## 요약
Member 및 회원가입 로직에 마케팅 수신 동의 여부 추가

## 내용
### Member 엔티티 객체 수정
```java
public class Member {

    @Id
    private UUID id;
    private String email;
    private String socialId;
    private String nickName;
    private String instagramId;
    private Double height;
    private Double reach;
    private String profileImageUrl;
    private Boolean hasAgreedToMarketing;
    @Enumerated(EnumType.STRING)
    private Gender gender;
    @Enumerated(EnumType.STRING)
    private Role role;
    ...
}
```
hasAgreedToMarketing 필드를 추가했고, 현재 Member를 생성할 때 builder를 이용하고 있기 때문에 사용하지 않는 정적 팩토리 메서드는 삭제했습니다.

### 로그인, 회원가입 로직 수정
현재 로그인 요청과 회원가입 요청을 한 API로 진행하고 있습니다. 
회원가입 시에만 마케팅 수신 동의 여부 값이 필수로 필요하기 때문에 dto에 대한 유효성 검사가 아닌 service 객체에서 유효성 검사를 진행했습니다.
```java
private Member saveOrGetMember(final Optional<Member> foundMember,
        final SocialInfo socialInfo, final Boolean hasAgreedToMarketing) {
        if (foundMember.isPresent()) {
            return foundMember.get();
        }
        if (Objects.isNull(hasAgreedToMarketing)) {
            throw new MarketingConsentRequiredException();
        }
        Member member = Member.builder()
                              .id(UUID.randomUUID())
                              .email(socialInfo.email())
                              .socialId(socialInfo.socialId())
                              .role(DEFAULT_ROLE)
                              .hasAgreedToMarketing(hasAgreedToMarketing)
                              .build();
        memberRepository.save(member);
        return member;
    }
```

### 로그인 요청 dto 수정
<img width="1274" alt="image" src="https://github.com/user-attachments/assets/b7676207-cecd-4edf-a16d-318f0b604b42">
마케팅 수신 동의 여부를 로그인 요청 dto에 추가했습니다.