### PR TITLE
등록되지 않은 유저가 다른 요청을 할 수 없도록 막는 기능 추가

### DIFF
--- a/src/main/java/com/first/flash/account/auth/application/AuthService.java
+++ b/src/main/java/com/first/flash/account/auth/application/AuthService.java
@@ -1,6 +1,6 @@
 package com.first.flash.account.auth.application;
 
-import static com.first.flash.account.member.domain.Role.ROLE_USER;
+import static com.first.flash.account.member.domain.Role.ROLE_UNREGISTERED_USER;
 
 import com.first.flash.account.auth.application.dto.LoginRequestDto;
 import com.first.flash.account.auth.application.dto.LoginResponseDto;
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class AuthService {
 
-    private static final Role DEFAULT_ROLE = ROLE_USER;
+    private static final Role DEFAULT_ROLE = ROLE_UNREGISTERED_USER;
 
     private final MemberRepository memberRepository;
     private final TokenManager tokenManager;

--- a/src/main/java/com/first/flash/account/member/domain/Member.java
+++ b/src/main/java/com/first/flash/account/member/domain/Member.java
@@ -38,6 +38,9 @@ public class Member {
     public void completeRegistration(final String nickName, final String instagramId,
         final Double height, final Gender gender, final Double reach,
         final String profileImageUrl) {
+        if (role.isUnregisteredUser()) {
+            role = Role.ROLE_USER;
+        }
         this.nickName = nickName;
         this.instagramId = instagramId;
         this.height = height;

--- a/src/main/java/com/first/flash/account/member/domain/Role.java
+++ b/src/main/java/com/first/flash/account/member/domain/Role.java
@@ -7,7 +7,12 @@ import lombok.ToString;
 @ToString
 public enum Role {
 
-    ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER"), ROLE_WEB("ROLE_WEB");
+    ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER"),
+    ROLE_WEB("ROLE_WEB"), ROLE_UNREGISTERED_USER("ROLE_UNREGISTERED_USER");
 
     private String role;
+
+    public boolean isUnregisteredUser() {
+        return this.equals(ROLE_UNREGISTERED_USER);
+    }
 }

--- a/src/main/java/com/first/flash/global/config/SecurityConfig.java
+++ b/src/main/java/com/first/flash/global/config/SecurityConfig.java
@@ -31,6 +31,7 @@ public class SecurityConfig {
         "/swagger-ui/*",
         "/v1/api-docs/**"
     };
+    private static final String COMPLETE_REGISTRATION = "/members";
 
     private final TokenManager tokenManager;
     private final UserDetailsService userDetailsService;
@@ -48,6 +49,7 @@ public class SecurityConfig {
                    .authorizeHttpRequests(authorize -> authorize
                        .requestMatchers(AUTH_WHITELIST).permitAll()
                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                       .requestMatchers(HttpMethod.PATCH, COMPLETE_REGISTRATION).hasAnyRole("ADMIN", "USER", "UNREGISTERED_USER")
                        .requestMatchers(HttpMethod.GET, "/**").hasAnyRole("ADMIN", "USER", "WEB")
                        .requestMatchers("/**").hasAnyRole("ADMIN", "USER")
                        .anyRequest().authenticated()

--- a/src/main/java/com/first/flash/global/filter/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/first/flash/global/filter/handler/CustomAccessDeniedHandler.java
@@ -1,5 +1,7 @@
 package com.first.flash.global.filter.handler;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.first.flash.global.filter.handler.dto.DeniedExceptionDto;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,6 +19,10 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
         response.setCharacterEncoding("UTF-8");
         response.setContentType("application/json; charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-        response.getWriter().write("요청에 대한 권한이 없습니다.");
+
+        DeniedExceptionDto defaultException = DeniedExceptionDto.createDefault();
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonResponse = objectMapper.writeValueAsString(defaultException);
+        response.getWriter().write(jsonResponse);
     }
 }

--- a/src/main/java/com/first/flash/global/filter/handler/dto/DeniedExceptionDto.java
+++ b/src/main/java/com/first/flash/global/filter/handler/dto/DeniedExceptionDto.java
@@ -1,0 +1,14 @@
+package com.first.flash.global.filter.handler.dto;
+
+import com.first.flash.account.member.domain.Role;
+import com.first.flash.global.util.AuthUtil;
+
+public record DeniedExceptionDto(String reason) {
+
+    public static DeniedExceptionDto createDefault() {
+        if (AuthUtil.hasRole(Role.ROLE_UNREGISTERED_USER.name())) {
+            return new DeniedExceptionDto("UNREGISTERED_USER");
+        }
+        return new DeniedExceptionDto("NOT_ALLOWED");
+    }
+}

--- a/src/main/java/com/first/flash/global/util/AuthUtil.java
+++ b/src/main/java/com/first/flash/global/util/AuthUtil.java
@@ -21,4 +21,8 @@ public class AuthUtil {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         return authentication.getAuthorities();
     }
+
+    public static Boolean hasRole(final String role) {
+        return getRoles().stream().anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(role));
+    }
 }


### PR DESCRIPTION
## 요약
추가 정보를 입력하지 않은 유저가 다른 요청을 하지 못하게 함으로써 온보딩 페이지를 건너뛸 수 없도록 했습니다.

## 내용
### ROLE_UNREGISTERED_USER 역할 추가
```java
public enum Role {

    ROLE_ADMIN("ROLE_ADMIN"), ROLE_USER("ROLE_USER"),
    ROLE_WEB("ROLE_WEB"), ROLE_UNREGISTERED_USER("ROLE_UNREGISTERED_USER");

    private String role;

    public boolean isUnregisteredUser() {
        return this.equals(ROLE_UNREGISTERED_USER);
    }
}
```
기존에 있던 USER를 등록되지 않은 유저와 등록된 유저로 분류했습니다.

### 등록되지 않은 유저는 정보 완성 API만 사용할 수 있도록 수정
```java
.requestMatchers(HttpMethod.PATCH, COMPLETE_REGISTRATION).hasAnyRole("ADMIN", "USER", "UNREGISTERED_USER")
```
이제 등록되지 않은 유저는 위 요청 외 요청을 보내게 되면, 403 FORBIDDEN 에러를 반환받습니다.
때문에 요청이 거부되는 403 에러와 구분이 필요해졌습니다.

### 403 에러를 reason 필드로 구분
```java
public record DeniedExceptionDto(String reason) {

    public static DeniedExceptionDto createDefault() {
        if (AuthUtil.hasRole(Role.ROLE_UNREGISTERED_USER.name())) {
            return new DeniedExceptionDto("UNREGISTERED_USER");
        }
        return new DeniedExceptionDto("NOT_ALLOWED");
    }
}
```
만약 유저가 ROLE_UNREGISTERED_USER 역할이라면 다른 reason을 갖게 됩니다.

### 유저가 특정 역할을 가지고 있는지 확인하는 메서드 추가
AuthUtil에서 현재 요청을 보낸 유저가 특정 역할이 있는지 확인하는 메서드를 추가했습니다.
```java
public static Boolean hasRole(final String role) {
        return getRoles().stream().anyMatch(grantedAuthority -> grantedAuthority.getAuthority().equals(role));
    }
```

