### PR TITLE
사진 출처 컬럼 추가, 마이페이지 정렬 수정, 섹터 예상 탈거일 수정

### DIFF
--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 @Builder
 public record ProblemCreateResponseDto(UUID id, String imageUrl, Integer views, Boolean isExpired,
                                        DifficultyInfo difficultyInfo, Long optionalWeight,
-                                       Long gymId, Long sectorId
+                                       Long gymId, Long sectorId, String source
 ) {
 
     public static ProblemCreateResponseDto toDto(final Problem problem) {
@@ -21,6 +21,7 @@ public record ProblemCreateResponseDto(UUID id, String imageUrl, Integer views, 
                                        .optionalWeight(problem.getOptionalWeight())
                                        .gymId(problem.getGymId())
                                        .sectorId(problem.getSectorId())
+                                       .source(problem.getSource())
                                        .build();
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
@@ -8,7 +8,7 @@ import lombok.Builder;
 @Builder
 public record ProblemCreateResponseDto(UUID id, String imageUrl, Integer views, Boolean isExpired,
                                        DifficultyInfo difficultyInfo, Long optionalWeight,
-                                       Long gymId, Long sectorId, String source
+                                       Long gymId, Long sectorId, String imageSource
 ) {
 
     public static ProblemCreateResponseDto toDto(final Problem problem) {
@@ -21,7 +21,7 @@ public record ProblemCreateResponseDto(UUID id, String imageUrl, Integer views, 
                                        .optionalWeight(problem.getOptionalWeight())
                                        .gymId(problem.getGymId())
                                        .sectorId(problem.getSectorId())
-                                       .source(problem.getSource())
+                                       .imageSource(problem.getImageSource())
                                        .build();
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
@@ -7,12 +7,13 @@ import java.util.UUID;
 public record ProblemDetailResponseDto(UUID id, String sector, String difficulty,
                                        LocalDate settingDate, LocalDate removalDate,
                                        boolean isFakeRemovalDate, boolean hasSolution,
-                                       String imageUrl, String gymName) {
+                                       String imageUrl, String gymName, String source) {
 
     public static ProblemDetailResponseDto of(final QueryProblem queryProblem) {
         return new ProblemDetailResponseDto(queryProblem.getId(), queryProblem.getSectorName(),
             queryProblem.getDifficultyName(), queryProblem.getSettingDate(),
             queryProblem.getRemovalDate(), queryProblem.getIsFakeRemovalDate(),
-            queryProblem.getHasSolution(), queryProblem.getImageUrl(), queryProblem.getGymName());
+            queryProblem.getHasSolution(), queryProblem.getImageUrl(), queryProblem.getGymName(),
+            queryProblem.getSource());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
@@ -7,13 +7,13 @@ import java.util.UUID;
 public record ProblemDetailResponseDto(UUID id, String sector, String difficulty,
                                        LocalDate settingDate, LocalDate removalDate,
                                        boolean isFakeRemovalDate, boolean hasSolution,
-                                       String imageUrl, String gymName, String source) {
+                                       String imageUrl, String gymName, String imageSource) {
 
     public static ProblemDetailResponseDto of(final QueryProblem queryProblem) {
         return new ProblemDetailResponseDto(queryProblem.getId(), queryProblem.getSectorName(),
             queryProblem.getDifficultyName(), queryProblem.getSettingDate(),
             queryProblem.getRemovalDate(), queryProblem.getIsFakeRemovalDate(),
             queryProblem.getHasSolution(), queryProblem.getImageUrl(), queryProblem.getGymName(),
-            queryProblem.getSource());
+            queryProblem.getImageSource());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
@@ -34,10 +34,11 @@ public class Problem {
     private Long optionalWeight;
     private Long gymId;
     private Long sectorId;
+    private String source;
 
     public static Problem createDefault(final UUID id, final String imageUrl,
         final String difficultyName, final Integer difficultyLevel, final Long gymId,
-        final Long sectorId) {
+        final Long sectorId, final String source) {
         return Problem.builder()
                       .id(id)
                       .imageUrl(imageUrl)
@@ -47,6 +48,7 @@ public class Problem {
                       .optionalWeight(DEFAULT_OPTIONAL_WEIGHT)
                       .gymId(gymId)
                       .sectorId(sectorId)
+                      .source(source)
                       .build();
     }
 

--- a/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
@@ -34,11 +34,11 @@ public class Problem {
     private Long optionalWeight;
     private Long gymId;
     private Long sectorId;
-    private String source;
+    private String imageSource;
 
     public static Problem createDefault(final UUID id, final String imageUrl,
         final String difficultyName, final Integer difficultyLevel, final Long gymId,
-        final Long sectorId, final String source) {
+        final Long sectorId, final String imageSource) {
         return Problem.builder()
                       .id(id)
                       .imageUrl(imageUrl)
@@ -48,7 +48,7 @@ public class Problem {
                       .optionalWeight(DEFAULT_OPTIONAL_WEIGHT)
                       .gymId(gymId)
                       .sectorId(sectorId)
-                      .source(source)
+                      .imageSource(imageSource)
                       .build();
     }
 

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
@@ -25,7 +25,7 @@ public class ProblemsCreateService {
         UUID generatedUUID = uuidGenerator.generate();
 
         return Problem.createDefault(generatedUUID, createRequestDto.imageUrl(),
-            difficulty.getName(), difficulty.getLevel(), climbingGym.getId(), sector.getId(), createRequestDto.source());
+            difficulty.getName(), difficulty.getLevel(), climbingGym.getId(), sector.getId(), createRequestDto.imageSource());
     }
 
     public QueryProblem createQueryProblem(final ClimbingGym climbingGym, final Sector sector,
@@ -42,7 +42,7 @@ public class ProblemsCreateService {
                            .difficultyName(problem.getDifficultyInfo().getDifficultyName())
                            .difficultyLevel(problem.getDifficultyInfo().getLevel())
                            .optionalWeight(problem.getOptionalWeight())
-                           .source(problem.getSource())
+                           .imageSource(problem.getImageSource())
                            .gymId(problem.getGymId())
                            .gymName(climbingGym.getGymName())
                            .sectorId(problem.getSectorId())

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
@@ -25,7 +25,7 @@ public class ProblemsCreateService {
         UUID generatedUUID = uuidGenerator.generate();
 
         return Problem.createDefault(generatedUUID, createRequestDto.imageUrl(),
-            difficulty.getName(), difficulty.getLevel(), climbingGym.getId(), sector.getId());
+            difficulty.getName(), difficulty.getLevel(), climbingGym.getId(), sector.getId(), createRequestDto.source());
     }
 
     public QueryProblem createQueryProblem(final ClimbingGym climbingGym, final Sector sector,
@@ -42,6 +42,7 @@ public class ProblemsCreateService {
                            .difficultyName(problem.getDifficultyInfo().getDifficultyName())
                            .difficultyLevel(problem.getDifficultyInfo().getLevel())
                            .optionalWeight(problem.getOptionalWeight())
+                           .source(problem.getSource())
                            .gymId(problem.getGymId())
                            .gymName(climbingGym.getGymName())
                            .sectorId(problem.getSectorId())

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -48,6 +48,7 @@ public class QueryProblem {
     private String difficultyName;
     private Integer difficultyLevel;
     private Long optionalWeight;
+    private String source;
     private Long gymId;
     private String gymName;
     private Long sectorId;

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -48,7 +48,7 @@ public class QueryProblem {
     private String difficultyName;
     private Integer difficultyLevel;
     private Long optionalWeight;
-    private String source;
+    private String imageSource;
     private Long gymId;
     private String gymName;
     private Long sectorId;

--- a/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotEmpty;
 
 public record ProblemCreateRequestDto(
     @NotEmpty(message = "이미지 URL은 필수입니다.") String imageUrl,
-    @NotEmpty(message = "난이도는 필수입니다.") String difficulty) {
+    @NotEmpty(message = "난이도는 필수입니다.") String difficulty,
+    @NotEmpty(message = "출처는 필수입니다.") String source) {
 
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
@@ -5,6 +5,6 @@ import jakarta.validation.constraints.NotEmpty;
 public record ProblemCreateRequestDto(
     @NotEmpty(message = "이미지 URL은 필수입니다.") String imageUrl,
     @NotEmpty(message = "난이도는 필수입니다.") String difficulty,
-    @NotEmpty(message = "출처는 필수입니다.") String source) {
+    @NotEmpty(message = "이미지 출처는 필수입니다.") String imageSource) {
 
 }

--- a/src/main/java/com/first/flash/climbing/sector/domain/vo/RemovalInfo.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/vo/RemovalInfo.java
@@ -14,7 +14,7 @@ import lombok.ToString;
 @ToString
 public class RemovalInfo {
 
-    private static final int FAKE_SECTOR_LIFETIME_DAYS = 30;
+    private static final int FAKE_SECTOR_LIFETIME_DAYS = 60;
 
     private LocalDate removalDate;
     private Boolean isFakeRemovalDate;

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -37,6 +37,7 @@ public class SolutionQueryDslRepository {
                               .on(solution.problemId.eq(queryProblem.id))
                               .fetchJoin()
                               .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
+                              .orderBy(solution.createdAt.desc())
                               .fetch();
     }
 

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -38,7 +38,7 @@ public class SolutionController {
     private final SolutionService solutionService;
     private final SolutionSaveService solutionSaveService;
 
-    @Operation(summary = "해설 조회", description = "본인이 등록한 해설 조회")
+    @Operation(summary = "내 해설 조회", description = "본인이 등록한 해설 조회")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공적으로 해설을 조회함",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = MySolutionsResponseDto.class)))

--- a/src/test/java/com/first/flash/climbing/problem/fixture/ProblemFixture.java
+++ b/src/test/java/com/first/flash/climbing/problem/fixture/ProblemFixture.java
@@ -11,7 +11,7 @@ public class ProblemFixture {
 
     public static Problem createDefault() {
         return Problem.createDefault(UUID.randomUUID(), "example.com", "difficultyName",
-            DEFAULT_DIFFICULTY_LEVEL, DEFAULT_GYM_ID, DEFAULT_SECTOR_ID);
+            DEFAULT_DIFFICULTY_LEVEL, DEFAULT_GYM_ID, DEFAULT_SECTOR_ID, "examplesource");
     }
 
 }


### PR DESCRIPTION
## 사진 출처 컬럼 추가

```java
public class Problem {

    // ...

    private String imageSource;
```

- imageSource 컬럼 추가
- 문제 생성, 문제 상세 정보 조회 응답에서 imageSource를 반환

## 마이페이지 정렬 수정

```java
    public List<MySolutionDto> findByUploaderId(final UUID uploaderId) {
        return jpaQueryFactory.select(Projections.constructor(MySolutionDto.class,
                                  solution.id, queryProblem.gymName, queryProblem.sectorName,
                                  queryProblem.difficultyName, queryProblem.imageUrl, solution.createdAt
                              ))
                              .from(solution)
                              .innerJoin(queryProblem)
                              .on(solution.problemId.eq(queryProblem.id))
                              .fetchJoin()
                              .where(solution.uploaderDetail.uploaderId.eq(uploaderId))
                              .orderBy(solution.createdAt.desc()) // 추가
                              .fetch();
    }
```

- 내가 업로드한 해설 반환 시 생성일 순으로 내림차순 정렬을 추가

## 섹터 예상 탈거일 수정

```java
public class RemovalInfo {

    private static final int FAKE_SECTOR_LIFETIME_DAYS = 60;
    // ...
```

- 섹터 정보 관리에 불편함이 있어 예상 탈거일을 +30일에서 +60일로 수정