### PR TITLE
존재하지 않는 유저의 영상을 해설로 업로드

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -85,4 +85,4 @@ jobs:
           AWS_REGION: ap-northeast-2
         run: |
           aws elasticbeanstalk create-application-version --application-name flash-application-dev --version-label ${{ github.sha }} --source-bundle S3Bucket=$AWS_S3_BUCKET,S3Key="dev/Dockerrun-${{ github.sha }}.aws.json"
-          aws elasticbeanstalk update-environment --application-name flash-application-dev --environment-name Flash-application-dev-env --version-label ${{ github.sha }}
+          aws elasticbeanstalk update-environment --application-name flash-application-dev --environment-name Flash-application-dev-env-1 --version-label ${{ github.sha }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: checkout code
         uses: actions/checkout@v2
 
       - name: Set up JDK 17

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -3,6 +3,7 @@ package com.first.flash.climbing.solution.application;
 import com.first.flash.account.member.application.MemberService;
 import com.first.flash.account.member.domain.Member;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.application.dto.UnregisteredMemberSolutionCreateRequest;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.domain.SolutionSavedEvent;
@@ -40,5 +41,19 @@ public class SolutionSaveService {
     public void updateUploaderInfo(final UUID uploaderId, final String nickName,
         final String instagramId, final String profileImageUrl) {
         solutionRepository.updateUploaderInfo(uploaderId, nickName, instagramId, profileImageUrl);
+    }
+
+    @Transactional
+    public SolutionResponseDto saveUnregisteredMemberSolution(final UUID problemId,
+        final UnregisteredMemberSolutionCreateRequest requestDto) {
+        UUID id = AuthUtil.getId();
+        Member member = memberService.findById(id);
+
+        Solution solution = Solution.of(requestDto.nickName(), requestDto.review(),
+            requestDto.instagramId(), requestDto.videoUrl(), problemId, member.getId(),
+            requestDto.profileImageUrl());
+        Solution savedSolution = solutionRepository.save(solution);
+        Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
+        return SolutionResponseDto.toDto(savedSolution);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.solution.application.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+public record UnregisteredMemberSolutionCreateRequest(
+    @NotEmpty(message = "닉네임은 필수입니다.") String nickName,
+    @NotEmpty(message = "인스타그램 아이디는 필수입니다.") String instagramId,
+    String review, String profileImageUrl,
+    @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -6,6 +6,7 @@ import com.first.flash.climbing.solution.application.dto.MySolutionsResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
+import com.first.flash.climbing.solution.application.dto.UnregisteredMemberSolutionCreateRequest;
 import com.first.flash.climbing.solution.domain.dto.SolutionCreateRequestDto;
 import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -99,6 +100,30 @@ public class SolutionController {
                              .body(
                                  solutionSaveService.saveSolution(problemId,
                                      solutionCreateRequestDto));
+    }
+
+    @Operation(summary = "없는 유저의 영상으로 해설 업로드", description = "없는 유저의 영상으로 해설 업로드")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "성공적으로 해설을 업로드함",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "요청값 누락", value = "{\"videoUrl\": \"비디오 URL은 필수입니다.\"}"),
+            })),
+        @ApiResponse(responseCode = "404", description = "문제를 찾을 수 없음",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "문제 없음", value = "{\"error\": \"아이디가 0190c558-9063-7050-b4fc-eb421e3236b3인 문제를 찾을 수 없습니다.\"}")
+            }))
+    })
+    @PostMapping("admin/problems/{problemId}/solutions")
+    public ResponseEntity<SolutionResponseDto> createUnregisteredMemberSolution(
+        @PathVariable final UUID problemId,
+        @Valid @RequestBody final UnregisteredMemberSolutionCreateRequest createRequestDto) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(
+                                 solutionSaveService.saveUnregisteredMemberSolution(problemId,
+                                     createRequestDto));
     }
 
     @Operation(summary = "해설 수정", description = "특정 해설 정보 수정")

--- a/src/main/java/com/first/flash/global/config/SecurityConfig.java
+++ b/src/main/java/com/first/flash/global/config/SecurityConfig.java
@@ -32,6 +32,8 @@ public class SecurityConfig {
         "/v1/api-docs/**"
     };
     private static final String COMPLETE_REGISTRATION = "/members";
+    private static final String MARKETING_CONSENT = "/members/marketing-consent";
+    private static final String NICKNAME_DUPLICATE = "/members/nickname";
 
     private final TokenManager tokenManager;
     private final UserDetailsService userDetailsService;
@@ -49,6 +51,8 @@ public class SecurityConfig {
                    .authorizeHttpRequests(authorize -> authorize
                        .requestMatchers(AUTH_WHITELIST).permitAll()
                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                       .requestMatchers(HttpMethod.POST, MARKETING_CONSENT).hasAnyRole("ADMIN", "USER", "UNREGISTERED_USER")
+                       .requestMatchers(HttpMethod.GET, NICKNAME_DUPLICATE).hasAnyRole("ADMIN", "USER", "UNREGISTERED_USER")
                        .requestMatchers(HttpMethod.PATCH, COMPLETE_REGISTRATION).hasAnyRole("ADMIN", "USER", "UNREGISTERED_USER")
                        .requestMatchers(HttpMethod.GET, "/**").hasAnyRole("ADMIN", "USER", "WEB")
                        .requestMatchers("/**").hasAnyRole("ADMIN", "USER")


### PR DESCRIPTION
## 요약
서비스에 회원가입하지 않은 유저의 영상을 해설 영상으로 업로드하는 어드민 API입니다.

## 내용
### 시나리오 추가
```java
@Transactional
    public SolutionResponseDto saveUnregisteredMemberSolution(final UUID problemId,
        final UnregisteredMemberSolutionCreateRequest requestDto) {
        UUID id = AuthUtil.getId();
        Member member = memberService.findById(id);

        Solution solution = Solution.of(requestDto.nickName(), requestDto.review(),
            requestDto.instagramId(), requestDto.videoUrl(), problemId, member.getId(),
            requestDto.profileImageUrl());
        Solution savedSolution = solutionRepository.save(solution);
        Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
        return SolutionResponseDto.toDto(savedSolution);
    }
```
solution의 nicckname, instagramId, profileImage 모두 요청을 보낸 유저의 값이 아닌 직접 요청에서 그 값을 지정할 수 있도록 했습니다.
```java
public record UnregisteredMemberSolutionCreateRequest(
    @NotEmpty(message = "닉네임은 필수입니다.") String nickName,
    @NotEmpty(message = "인스타그램 아이디는 필수입니다.") String instagramId,
    String review, String profileImageUrl,
    @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl) {

}
```
이때 review와 profileImageUrl은 null이 가능하도록 했습니다.

