### PR TITLE
해설에 대한 답장 CRUD

### DIFF
--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
@@ -7,7 +7,6 @@ import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRe
 import com.first.flash.climbing.solution.application.dto.SolutionCommentResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
-import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionComment;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionCommentAccessDeniedException;
@@ -50,7 +49,8 @@ public class SolutionCommentService {
     }
 
     public SolutionCommentsResponseDto findBySolutionId(final Long solutionId) {
-        List<SolutionComment> comments = solutionCommentRepository.findBySolutionId(solutionId);
+        List<SolutionComment> comments = solutionService.findSolutionById(solutionId)
+                                                        .getComments();
         List<SolutionCommentResponseDto> commentsResponse = comments.stream()
                                                                     .map(
                                                                         SolutionCommentResponseDto::toDto)

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
@@ -59,13 +59,14 @@ public class SolutionCommentService {
     }
 
     @Transactional
-    public SolutionResponseDto updateComment(final Long commentId, final SolutionCommentUpdateRequestDto request) {
+    public SolutionCommentResponseDto updateComment(final Long commentId,
+        final SolutionCommentUpdateRequestDto request) {
         SolutionComment comment = findById(commentId);
         if (!AuthUtil.isSameId(comment.getCommenterDetail().getCommenterId())) {
             throw new SolutionCommentAccessDeniedException();
         }
         comment.updateContent(request.content());
-        return SolutionResponseDto.toDto(comment.getSolution());
+        return SolutionCommentResponseDto.toDto(comment);
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
@@ -5,6 +5,7 @@ import com.first.flash.account.member.domain.Member;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionComment;
@@ -57,12 +58,12 @@ public class SolutionCommentService {
     }
 
     @Transactional
-    public void updateComment(final Long commentId, final String content) {
+    public void updateComment(final Long commentId, final SolutionCommentUpdateRequestDto request) {
         SolutionComment comment = findById(commentId);
         if (!AuthUtil.isSameId(comment.getCommenterDetail().getCommenterId())) {
             throw new SolutionCommentAccessDeniedException();
         }
-        comment.updateContent(content);
+        comment.updateContent(request.content());
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
@@ -7,6 +7,7 @@ import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRe
 import com.first.flash.climbing.solution.application.dto.SolutionCommentResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionComment;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionCommentAccessDeniedException;
@@ -58,12 +59,13 @@ public class SolutionCommentService {
     }
 
     @Transactional
-    public void updateComment(final Long commentId, final SolutionCommentUpdateRequestDto request) {
+    public SolutionResponseDto updateComment(final Long commentId, final SolutionCommentUpdateRequestDto request) {
         SolutionComment comment = findById(commentId);
         if (!AuthUtil.isSameId(comment.getCommenterDetail().getCommenterId())) {
             throw new SolutionCommentAccessDeniedException();
         }
         comment.updateContent(request.content());
+        return SolutionResponseDto.toDto(comment.getSolution());
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
@@ -30,12 +30,12 @@ public class SolutionCommentService {
 
     @Transactional
     public SolutionCommentCreateResponseDto createComment(final Long solutionId,
-        final SolutionCommentCreateRequestDto requestDto) {
+        final SolutionCommentCreateRequestDto request) {
         UUID id = AuthUtil.getId();
         Member member = memberService.findById(id);
 
         Solution solution = solutionService.findSolutionById(solutionId);
-        SolutionComment solutionComment = SolutionComment.of(requestDto.content(),
+        SolutionComment solutionComment = SolutionComment.of(request.content(),
             member.getNickName(), member.getProfileImageUrl(), member.getId(), solution);
         SolutionComment savedSolutionComment = solutionCommentRepository.save(solutionComment);
 

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
@@ -43,7 +43,8 @@ public class SolutionCommentService {
 
     public SolutionComment findById(final Long id) {
         return solutionCommentRepository.findById(id)
-                                       .orElseThrow(() -> new SolutionCommentNotFoundException(id));
+                                        .orElseThrow(
+                                            () -> new SolutionCommentNotFoundException(id));
     }
 
     public SolutionCommentsResponseDto findBySolutionId(final Long solutionId) {
@@ -56,13 +57,12 @@ public class SolutionCommentService {
     }
 
     @Transactional
-    public void updateCommenterInfo(final Long commentId, final UUID commenterId, final String nickName,
-        final String profileImageUrl) {
+    public void updateComment(final Long commentId, final String content) {
         SolutionComment comment = findById(commentId);
         if (!AuthUtil.isSameId(comment.getCommenterDetail().getCommenterId())) {
             throw new SolutionCommentAccessDeniedException();
         }
-        solutionCommentRepository.updateCommenterInfo(commenterId, nickName, profileImageUrl);
+        comment.updateContent(content);
     }
 
     @Transactional
@@ -77,5 +77,11 @@ public class SolutionCommentService {
     @Transactional
     public void deleteByCommenterId(final UUID commenterId) {
         solutionCommentRepository.deleteByCommenterId(commenterId);
+    }
+
+    @Transactional
+    public void updateCommenterInfo(final UUID commenterId, final String nickName,
+        final String profileImageUrl) {
+        solutionCommentRepository.updateCommenterInfo(commenterId, nickName, profileImageUrl);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionCommentService.java
@@ -1,0 +1,49 @@
+package com.first.flash.climbing.solution.application;
+
+import com.first.flash.account.member.application.MemberService;
+import com.first.flash.account.member.domain.Member;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRequestDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
+import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.domain.SolutionComment;
+import com.first.flash.climbing.solution.infrastructure.SolutionCommentRepository;
+import com.first.flash.global.util.AuthUtil;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SolutionCommentService {
+
+    private final MemberService memberService;
+    private final SolutionCommentRepository solutionCommentRepository;
+    private final SolutionService solutionService;
+
+    public SolutionCommentCreateResponseDto createComment(final Long solutionId,
+        final SolutionCommentCreateRequestDto requestDto) {
+        UUID id = AuthUtil.getId();
+        Member member = memberService.findById(id);
+
+        Solution solution = solutionService.findSolutionById(solutionId);
+        SolutionComment solutionComment = SolutionComment.of(requestDto.content(),
+            member.getNickName(), member.getId(), solution);
+        SolutionComment savedSolutionComment = solutionCommentRepository.save(solutionComment);
+
+        return SolutionCommentCreateResponseDto.toDto(savedSolutionComment);
+    }
+
+    public SolutionCommentsResponseDto findBySolutionId(final Long solutionId) {
+        List<SolutionComment> comments = solutionCommentRepository.findBySolutionId(solutionId);
+        List<SolutionCommentResponseDto> commentsResponse = comments.stream()
+                                                                    .map(
+                                                                        SolutionCommentResponseDto::toDto)
+                                                                    .toList();
+        return SolutionCommentsResponseDto.from(commentsResponse);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionEventHandler.java
@@ -13,17 +13,22 @@ public class SolutionEventHandler {
 
     private final SolutionSaveService solutionSaveService;
     private final SolutionService solutionService;
+    private final SolutionCommentService solutionCommentService;
 
     @EventListener
     @Transactional
     public void updateSolutionInfo(final MemberInfoUpdatedEvent event) {
         solutionSaveService.updateUploaderInfo(event.getMemberId(), event.getNickName(),
             event.getInstagramId(), event.getProfileImageUrl());
+
+        solutionCommentService.updateCommenterInfo(event.getMemberId(), event.getNickName(),
+            event.getProfileImageUrl());
     }
 
     @EventListener
     @Transactional
     public void deleteSolution(final MemberDeletedEvent event) {
         solutionService.deleteByUploaderId(event.getMemberId());
+        solutionCommentService.deleteByCommenterId(event.getMemberId());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateRequestDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.climbing.solution.application.dto;
+
+public record SolutionCommentCreateRequestDto(String content) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateRequestDto.java
@@ -1,5 +1,7 @@
 package com.first.flash.climbing.solution.application.dto;
 
-public record SolutionCommentCreateRequestDto(String content) {
+import jakarta.validation.constraints.NotEmpty;
+
+public record SolutionCommentCreateRequestDto(@NotEmpty String content) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateResponseDto.java
@@ -1,11 +1,16 @@
 package com.first.flash.climbing.solution.application.dto;
 
 import com.first.flash.climbing.solution.domain.SolutionComment;
+import java.util.UUID;
 
-public record SolutionCommentCreateResponseDto() {
+public record SolutionCommentCreateResponseDto(Long id, String content, UUID commenterId,
+                                               String nickName, String profileImageUrl) {
 
     public static SolutionCommentCreateResponseDto toDto(
-        final SolutionComment savedSolutionComment) {
-        return new SolutionCommentCreateResponseDto();
+        final SolutionComment comment) {
+        return new SolutionCommentCreateResponseDto(comment.getId(), comment.getContent(),
+            comment.getCommenterDetail().getCommenterId(),
+            comment.getCommenterDetail().getCommenter(),
+            comment.getCommenterDetail().getProfileImageUrl());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentCreateResponseDto.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.solution.application.dto;
+
+import com.first.flash.climbing.solution.domain.SolutionComment;
+
+public record SolutionCommentCreateResponseDto() {
+
+    public static SolutionCommentCreateResponseDto toDto(
+        final SolutionComment savedSolutionComment) {
+        return new SolutionCommentCreateResponseDto();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentResponseDto.java
@@ -1,10 +1,15 @@
 package com.first.flash.climbing.solution.application.dto;
 
 import com.first.flash.climbing.solution.domain.SolutionComment;
+import java.util.UUID;
 
-public record SolutionCommentResponseDto() {
+public record SolutionCommentResponseDto(Long id, String content, UUID commenterId, String nickName,
+                                         String profileImageUrl) {
 
     public static SolutionCommentResponseDto toDto(final SolutionComment solutionComment) {
-        return new SolutionCommentResponseDto();
+        return new SolutionCommentResponseDto(solutionComment.getId(), solutionComment.getContent(),
+            solutionComment.getCommenterDetail().getCommenterId(),
+            solutionComment.getCommenterDetail().getCommenter(),
+            solutionComment.getCommenterDetail().getProfileImageUrl());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentResponseDto.java
@@ -1,15 +1,18 @@
 package com.first.flash.climbing.solution.application.dto;
 
 import com.first.flash.climbing.solution.domain.SolutionComment;
+import com.first.flash.global.util.AuthUtil;
 import java.util.UUID;
 
 public record SolutionCommentResponseDto(Long id, String content, UUID commenterId, String nickName,
-                                         String profileImageUrl) {
+                                         String profileImageUrl, boolean isMine) {
 
     public static SolutionCommentResponseDto toDto(final SolutionComment solutionComment) {
         return new SolutionCommentResponseDto(solutionComment.getId(), solutionComment.getContent(),
             solutionComment.getCommenterDetail().getCommenterId(),
             solutionComment.getCommenterDetail().getCommenter(),
-            solutionComment.getCommenterDetail().getProfileImageUrl());
+            solutionComment.getCommenterDetail().getProfileImageUrl(),
+            solutionComment.getCommenterDetail().getCommenterId().equals(AuthUtil.getId())
+        );
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentResponseDto.java
@@ -1,0 +1,10 @@
+package com.first.flash.climbing.solution.application.dto;
+
+import com.first.flash.climbing.solution.domain.SolutionComment;
+
+public record SolutionCommentResponseDto() {
+
+    public static SolutionCommentResponseDto toDto(final SolutionComment solutionComment) {
+        return new SolutionCommentResponseDto();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentUpdateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentUpdateRequestDto.java
@@ -1,5 +1,7 @@
 package com.first.flash.climbing.solution.application.dto;
 
-public record SolutionCommentUpdateRequestDto(String content) {
+import jakarta.validation.constraints.NotNull;
+
+public record SolutionCommentUpdateRequestDto(@NotNull String content) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentUpdateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentUpdateRequestDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.climbing.solution.application.dto;
+
+public record SolutionCommentUpdateRequestDto(String content) {
+
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionCommentsResponseDto.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.solution.application.dto;
+
+import java.util.List;
+
+public record SolutionCommentsResponseDto(List<SolutionCommentResponseDto> comments) {
+
+    public static SolutionCommentsResponseDto from(
+        final List<SolutionCommentResponseDto> commentsResponse) {
+        return new SolutionCommentsResponseDto(commentsResponse);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/CommenterDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/CommenterDetail.java
@@ -1,0 +1,32 @@
+package com.first.flash.climbing.solution.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import java.util.UUID;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Embeddable
+@NoArgsConstructor
+@EqualsAndHashCode
+@Getter
+@ToString
+public class CommenterDetail {
+
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID commenterId;
+    private String commenter;
+    private String profileImageUrl;
+
+    protected CommenterDetail(final UUID commenterId, final String commenter, final String profileImageUrl) {
+        this.commenterId = commenterId;
+        this.commenter = commenter;
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public static CommenterDetail of(final UUID commenterId, final String commenter, final String profileImageUrl) {
+        return new CommenterDetail(commenterId, commenter, profileImageUrl);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -3,11 +3,14 @@ package com.first.flash.climbing.solution.domain;
 import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
 import com.first.flash.climbing.solution.domain.vo.UploaderDetail;
 import com.first.flash.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -31,6 +34,9 @@ public class Solution extends BaseEntity {
     private SolutionDetail solutionDetail;
     private UploaderDetail uploaderDetail;
     private Long optionalWeight;
+    @OneToMany(mappedBy = "solution", cascade = CascadeType.ALL, orphanRemoval = true)
+    @ToString.Exclude
+    private List<SolutionComment> comments;
 
     protected Solution(final String uploader, final String review, final String instagramId,
         final String videoUrl, final UUID problemId, final UUID uploaderId,

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionComment.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionComment.java
@@ -1,7 +1,6 @@
 package com.first.flash.climbing.solution.domain;
 
 import com.first.flash.global.domain.BaseEntity;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -32,7 +31,7 @@ public class SolutionComment extends BaseEntity {
 
     private CommenterDetail commenterDetail;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "solution_id", nullable = false)
     private Solution solution;
 

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionComment.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionComment.java
@@ -1,0 +1,57 @@
+package com.first.flash.climbing.solution.domain;
+
+import com.first.flash.global.domain.BaseEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class SolutionComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String content;
+
+    @Column
+    private String commenter;
+
+    @Column
+    private UUID commenterId;
+
+    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @JoinColumn(name = "solution_id", nullable = false)
+    private Solution solution;
+
+    protected SolutionComment(final String content, final String commenter, final UUID commenterId, final Solution solution) {
+        this.content = content;
+        this.commenter = commenter;
+        this.commenterId = commenterId;
+        this.solution = solution;
+    }
+
+    public static SolutionComment of(final String content, final String commenter, final UUID commenterId, final Solution solution) {
+        return new SolutionComment(content, commenter, commenterId, solution);
+    }
+
+    public void updateContent(final String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionComment.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionComment.java
@@ -30,25 +30,20 @@ public class SolutionComment extends BaseEntity {
     @Column
     private String content;
 
-    @Column
-    private String commenter;
-
-    @Column
-    private UUID commenterId;
+    private CommenterDetail commenterDetail;
 
     @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     @JoinColumn(name = "solution_id", nullable = false)
     private Solution solution;
 
-    protected SolutionComment(final String content, final String commenter, final UUID commenterId, final Solution solution) {
+    protected SolutionComment(final String content, final CommenterDetail commenter, final Solution solution) {
         this.content = content;
-        this.commenter = commenter;
-        this.commenterId = commenterId;
+        this.commenterDetail = commenter;
         this.solution = solution;
     }
 
-    public static SolutionComment of(final String content, final String commenter, final UUID commenterId, final Solution solution) {
-        return new SolutionComment(content, commenter, commenterId, solution);
+    public static SolutionComment of(final String content, final String commenter, final String profileImage, final UUID commenterId, final Solution solution) {
+        return new SolutionComment(content, CommenterDetail.of(commenterId, commenter, profileImage), solution);
     }
 
     public void updateContent(final String content) {

--- a/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.first.flash.climbing.solution.exception;
 
 import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeniedException;
+import com.first.flash.climbing.solution.exception.exceptions.SolutionCommentAccessDeniedException;
+import com.first.flash.climbing.solution.exception.exceptions.SolutionCommentNotFoundException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import com.first.flash.global.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatus;
@@ -14,16 +16,31 @@ public class SolutionExceptionHandler {
     @ExceptionHandler(SolutionNotFoundException.class)
     public ResponseEntity<ErrorResponseDto> handleSolutionNotFoundException(
         final SolutionNotFoundException exception) {
-        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                             .body(errorResponse);
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
     @ExceptionHandler(SolutionAccessDeniedException.class)
     public ResponseEntity<ErrorResponseDto> handleSolutionAccessDeniedException(
         final SolutionAccessDeniedException exception) {
+        return getResponseWithStatus(HttpStatus.FORBIDDEN, exception);
+    }
+
+    @ExceptionHandler(SolutionCommentAccessDeniedException.class)
+    public ResponseEntity<ErrorResponseDto> handleSolutionCommentAccessDeniedException(
+        final SolutionCommentAccessDeniedException exception) {
+        return getResponseWithStatus(HttpStatus.FORBIDDEN, exception);
+    }
+
+    @ExceptionHandler(SolutionCommentNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleSolutionCommentNotFoundException(
+        final SolutionCommentNotFoundException exception) {
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
+    }
+
+    private ResponseEntity<ErrorResponseDto> getResponseWithStatus(final HttpStatus httpStatus,
+        final RuntimeException exception) {
         ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+        return ResponseEntity.status(httpStatus)
                              .body(errorResponse);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionCommentAccessDeniedException.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionCommentAccessDeniedException.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.solution.exception.exceptions;
+
+public class SolutionCommentAccessDeniedException extends RuntimeException {
+
+    public SolutionCommentAccessDeniedException() {
+        super("해당 댓글에 접근할 권한이 없습니다.");
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionCommentNotFoundException.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/exceptions/SolutionCommentNotFoundException.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.solution.exception.exceptions;
+
+public class SolutionCommentNotFoundException extends RuntimeException {
+
+    public SolutionCommentNotFoundException(final Long id) {
+        super(String.format("아이디가 %s인 댓글을 찾을 수 없습니다.", id));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentJpaRepository.java
@@ -1,0 +1,12 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import com.first.flash.climbing.solution.domain.SolutionComment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SolutionCommentJpaRepository extends JpaRepository<SolutionComment, Long> {
+
+    SolutionComment save(final SolutionComment solutionComment);
+
+    List<SolutionComment> findBySolutionId(final Long solutionId);
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentJpaRepository.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.solution.infrastructure;
 
 import com.first.flash.climbing.solution.domain.SolutionComment;
 import java.util.List;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SolutionCommentJpaRepository extends JpaRepository<SolutionComment, Long> {
@@ -9,4 +10,8 @@ public interface SolutionCommentJpaRepository extends JpaRepository<SolutionComm
     SolutionComment save(final SolutionComment solutionComment);
 
     List<SolutionComment> findBySolutionId(final Long solutionId);
+
+    void deleteByCommenterDetailCommenterId(final UUID commenterId);
+
+    void delete(final SolutionComment comment);
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentQueryDslRepository.java
@@ -1,0 +1,25 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import static com.first.flash.climbing.solution.domain.QSolutionComment.solutionComment;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SolutionCommentQueryDslRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+
+    public void updateCommenterInfo(final UUID commenterId, final String nickName,
+        final String profileImageUrl) {
+        jpaQueryFactory.update(solutionComment)
+            .set(solutionComment.commenterDetail.commenter, nickName)
+            .set(solutionComment.commenterDetail.profileImageUrl, profileImageUrl)
+            .where(solutionComment.commenterDetail.commenterId.eq(commenterId))
+            .execute();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepository.java
@@ -2,6 +2,8 @@ package com.first.flash.climbing.solution.infrastructure;
 
 import com.first.flash.climbing.solution.domain.SolutionComment;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -9,5 +11,13 @@ public interface SolutionCommentRepository {
 
     SolutionComment save(final SolutionComment solutionComment);
 
-    List<SolutionComment> findBySolutionId(Long solutionId);
+    Optional<SolutionComment> findById(final Long id);
+
+    List<SolutionComment> findBySolutionId(final Long solutionId);
+
+    void deleteByCommenterId(final UUID commenterId);
+
+    void updateCommenterInfo(final UUID commenterId, final String nickName, final String profileImageUrl);
+
+    void delete(final SolutionComment comment);
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepository.java
@@ -1,0 +1,13 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import com.first.flash.climbing.solution.domain.SolutionComment;
+import java.util.List;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SolutionCommentRepository {
+
+    SolutionComment save(final SolutionComment solutionComment);
+
+    List<SolutionComment> findBySolutionId(Long solutionId);
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepositoryImpl.java
@@ -1,0 +1,23 @@
+package com.first.flash.climbing.solution.infrastructure;
+
+import com.first.flash.climbing.solution.domain.SolutionComment;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SolutionCommentRepositoryImpl implements SolutionCommentRepository {
+
+    private final SolutionCommentJpaRepository solutionCommentJpaRepository;
+
+    @Override
+    public SolutionComment save(final SolutionComment solutionComment) {
+        return solutionCommentJpaRepository.save(solutionComment);
+    }
+
+    @Override
+    public List<SolutionComment> findBySolutionId(final Long solutionId) {
+        return solutionCommentJpaRepository.findBySolutionId(solutionId);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionCommentRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.first.flash.climbing.solution.infrastructure;
 
 import com.first.flash.climbing.solution.domain.SolutionComment;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -10,6 +12,7 @@ import org.springframework.stereotype.Repository;
 public class SolutionCommentRepositoryImpl implements SolutionCommentRepository {
 
     private final SolutionCommentJpaRepository solutionCommentJpaRepository;
+    private final SolutionCommentQueryDslRepository solutionCommentQueryDslRepository;
 
     @Override
     public SolutionComment save(final SolutionComment solutionComment) {
@@ -17,7 +20,28 @@ public class SolutionCommentRepositoryImpl implements SolutionCommentRepository 
     }
 
     @Override
+    public Optional<SolutionComment> findById(final Long id) {
+        return solutionCommentJpaRepository.findById(id);
+    }
+
+    @Override
     public List<SolutionComment> findBySolutionId(final Long solutionId) {
         return solutionCommentJpaRepository.findBySolutionId(solutionId);
+    }
+
+    @Override
+    public void deleteByCommenterId(final UUID commenterId) {
+        solutionCommentJpaRepository.deleteByCommenterDetailCommenterId(commenterId);
+    }
+
+    @Override
+    public void updateCommenterInfo(final UUID commenterId, final String nickName,
+        final String profileImageUrl) {
+        solutionCommentQueryDslRepository.updateCommenterInfo(commenterId, nickName, profileImageUrl);
+    }
+
+    @Override
+    public void delete(final SolutionComment comment) {
+        solutionCommentJpaRepository.delete(comment);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
@@ -1,0 +1,57 @@
+package com.first.flash.climbing.solution.ui;
+
+import com.first.flash.climbing.solution.application.SolutionCommentService;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRequestDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentUpdateRequestDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "solutions", description = "해설 관리 API")
+@RestController
+@RequiredArgsConstructor
+public class SolutionCommentController {
+
+    private final SolutionCommentService solutionCommentService;
+
+    @PostMapping("/solutions/{solutionId}/comments")
+    public ResponseEntity<SolutionCommentCreateResponseDto> createSolutionComment(
+        @PathVariable final Long solutionId,
+        @RequestBody final SolutionCommentCreateRequestDto request) {
+        SolutionCommentCreateResponseDto comment = solutionCommentService
+            .createComment(solutionId, request);
+        return ResponseEntity.ok(comment);
+    }
+
+    @GetMapping("/solutions/{solutionId}/comments")
+    public ResponseEntity<SolutionCommentsResponseDto> getSolutionComments(
+        @PathVariable final Long solutionId) {
+        SolutionCommentsResponseDto comments = solutionCommentService
+            .findBySolutionId(solutionId);
+        return ResponseEntity.ok(comments);
+    }
+
+    @PatchMapping("/comments/{commentId}")
+    public ResponseEntity<Void> updateComment(
+        @PathVariable final Long commentId,
+        @RequestBody final SolutionCommentUpdateRequestDto content) {
+        solutionCommentService.updateComment(commentId, content);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+        @PathVariable final Long commentId) {
+        solutionCommentService.deleteComment(commentId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
@@ -3,6 +3,7 @@ package com.first.flash.climbing.solution.ui;
 import com.first.flash.climbing.solution.application.SolutionCommentService;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionCommentResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
@@ -90,10 +91,10 @@ public class SolutionCommentController {
             }))
     })
     @PatchMapping("/comments/{commentId}")
-    public ResponseEntity<SolutionResponseDto> updateComment(
+    public ResponseEntity<SolutionCommentResponseDto> updateComment(
         @PathVariable final Long commentId,
         @RequestBody @Valid final SolutionCommentUpdateRequestDto content) {
-        SolutionResponseDto response = solutionCommentService.updateComment(commentId,
+        SolutionCommentResponseDto response = solutionCommentService.updateComment(commentId,
             content);
         return ResponseEntity.status(HttpStatus.OK)
                              .body(response);

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
@@ -93,9 +93,9 @@ public class SolutionCommentController {
     @PatchMapping("/comments/{commentId}")
     public ResponseEntity<SolutionCommentResponseDto> updateComment(
         @PathVariable final Long commentId,
-        @RequestBody @Valid final SolutionCommentUpdateRequestDto content) {
+        @RequestBody @Valid final SolutionCommentUpdateRequestDto request) {
         SolutionCommentResponseDto response = solutionCommentService.updateComment(commentId,
-            content);
+            request);
         return ResponseEntity.status(HttpStatus.OK)
                              .body(response);
     }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
@@ -6,7 +6,9 @@ import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRe
 import com.first.flash.climbing.solution.application.dto.SolutionCommentUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -26,10 +28,11 @@ public class SolutionCommentController {
     @PostMapping("/solutions/{solutionId}/comments")
     public ResponseEntity<SolutionCommentCreateResponseDto> createSolutionComment(
         @PathVariable final Long solutionId,
-        @RequestBody final SolutionCommentCreateRequestDto request) {
+        @RequestBody @Valid final SolutionCommentCreateRequestDto request) {
         SolutionCommentCreateResponseDto comment = solutionCommentService
             .createComment(solutionId, request);
-        return ResponseEntity.ok(comment);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(comment);
     }
 
     @GetMapping("/solutions/{solutionId}/comments")
@@ -43,7 +46,7 @@ public class SolutionCommentController {
     @PatchMapping("/comments/{commentId}")
     public ResponseEntity<Void> updateComment(
         @PathVariable final Long commentId,
-        @RequestBody final SolutionCommentUpdateRequestDto content) {
+        @RequestBody @Valid final SolutionCommentUpdateRequestDto content) {
         solutionCommentService.updateComment(commentId, content);
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
@@ -36,7 +36,7 @@ public class SolutionCommentController {
     @Operation(summary = "해설 댓글 생성", description = "특정 해설에 대한 댓글 생성")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "성공적으로 댓글 생성",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionCommentCreateRequestDto.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionCommentCreateResponseDto.class))),
         @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "요청값 누락", value = "{\"error\": \"content는 필수입니다.\"}"),


### PR DESCRIPTION
## 요약
- 해설 댓글 CRUD 구현
- 댓글자의 정보가 변경되었을 때 반영
- 댓글을 단 멤버가 탈퇴했을 때 생성한 댓글 모두 삭제
- 해설이 삭제되면,해당 해설의 댓글도 모두 삭제
- 댓글을 단 사람만 수정, 삭제할 수 있음
# 내용
## 엔티티 

_SolutionComment_
```java
public class SolutionComment extends BaseEntity {

    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;

    @Column
    private String content;

    private CommenterDetail commenterDetail;

    @ManyToOne(fetch = FetchType.LAZY)
    @JoinColumn(name = "solution_id", nullable = false)
    private Solution solution;
}
```
해설에 대한 댓글 엔티티 클래스입니다.
해설을 생성한 commenter에 대한 정보들은 아래 CommenterDetail로 분리했습니다.
루트 애그리거트인 Solution이 삭제될 경우 한번에 삭제될 수 있도록 다대일 연관관계 매핑을 했습니다.
**Solution이 호출될 때마다 Comment를 불러오는 성능 이슈가 없도록 FetchType을 LAZY로 설정**했습니다.

_CommenterDetail_
```java
public class CommenterDetail {

    @Column(columnDefinition = "BINARY(16)")
    private UUID commenterId;
    private String commenter;
    private String profileImageUrl;
}
```
댓글 단 멤버의 세부 정보 클래스입니다.
해당 멤버의 id와 nickname, profileImageUrl을 필드로 갖도록 했습니다.

_Solution_
```java
public class Solution extends BaseEntity {
    ...
    @OneToMany(mappedBy = "solution", cascade = CascadeType.ALL, orphanRemoval = true)
    @ToString.Exclude
    private List<SolutionComment> comments;
    ....
}
```
**Solution이 삭제되면 해당 Solution의 comment도 같이 삭제되도록 Cascade 설정을 추가**했습니다.
양방향 연관관계 매핑이다보니 ToString으로 인해 순환 참조가 발생해 ToString.Exclude를 추가했습니다.

## CRUD 구현
### 생성
```java
@Transactional
    public SolutionCommentCreateResponseDto createComment(final Long solutionId,
        final SolutionCommentCreateRequestDto requestDto) {
        UUID id = AuthUtil.getId();
        Member member = memberService.findById(id);

        Solution solution = solutionService.findSolutionById(solutionId);
        SolutionComment solutionComment = SolutionComment.of(requestDto.content(),
            member.getNickName(), member.getProfileImageUrl(), member.getId(), solution);
        SolutionComment savedSolutionComment = solutionCommentRepository.save(solutionComment);

        return SolutionCommentCreateResponseDto.toDto(savedSolutionComment);
    }
```
위 CommenterDetail을 위한 정보를 받고, RequestDto로부터 받은 content값으로 댓글을 생성합니다.

### 조회
```java
public SolutionCommentsResponseDto findBySolutionId(final Long solutionId) {
        List<SolutionComment> comments = solutionService.findSolutionById(solutionId)
                                                        .getComments();
        List<SolutionCommentResponseDto> commentsResponse = comments.stream()
                                                                    .map(
                                                                        SolutionCommentResponseDto::toDto)
                                                                    .toList();
        return SolutionCommentsResponseDto.from(commentsResponse);
    }
```
해설 id로 해당 해설의 댓글을 조회하도록 했습니다.

### 수정
```java
@Transactional
    public SolutionCommentResponseDto updateComment(final Long commentId,
        final SolutionCommentUpdateRequestDto request) {
        SolutionComment comment = findById(commentId);
        if (!AuthUtil.isSameId(comment.getCommenterDetail().getCommenterId())) {
            throw new SolutionCommentAccessDeniedException();
        }
        comment.updateContent(request.content());
        return SolutionCommentResponseDto.toDto(comment);
    } 
```
먼저 수정하고자 하는 댓글의 작성자와 요청을 보낸 유저의 id를 확인한 후 **본인이 아닐 경우 예외처리**합니다.
본인이 맞을 경우 원하는 content로 댓글을 수정합니다.

### 삭제
```java
@Transactional
    public void deleteComment(final Long commentId) {
        SolutionComment comment = findById(commentId);
        if (!AuthUtil.isSameId(comment.getCommenterDetail().getCommenterId())) {
            throw new SolutionCommentAccessDeniedException();
        }
        solutionCommentRepository.delete(comment);
    }
```
위 수정과 동일한 과정을 거친 후 삭제 처리합니다.

## 작성자의 수정/삭제 반영
```java
@EventListener
    @Transactional
    public void updateSolutionInfo(final MemberInfoUpdatedEvent event) {
        solutionSaveService.updateUploaderInfo(event.getMemberId(), event.getNickName(),
            event.getInstagramId(), event.getProfileImageUrl());

        solutionCommentService.updateCommenterInfo(event.getMemberId(), event.getNickName(),
            event.getProfileImageUrl());
    }

    @EventListener
    @Transactional
    public void deleteSolution(final MemberDeletedEvent event) {
        solutionService.deleteByUploaderId(event.getMemberId());
        solutionCommentService.deleteByCommenterId(event.getMemberId());
    }
```
기존 SolutionEventHandler에 댓글에 대한 작업도 추가했습니다.

### 수정
```java
@Transactional
    public void updateCommenterInfo(final UUID commenterId, final String nickName,
        final String profileImageUrl) {
        solutionCommentRepository.updateCommenterInfo(commenterId, nickName, profileImageUrl);
    }
```
벌크 연산으로 변경된 멤버의 닉네임과 프로필 이미지를 반영합니다.

### 삭제
```java
@Transactional
    public void deleteByCommenterId(final UUID commenterId) {
        solutionCommentRepository.deleteByCommenterId(commenterId);
    }
```
삭제된 멤버의 id를 작성자 id로 가지는 데이터들을 모두 삭제합니다.