### PR TITLE
해설에 댓글 개수 추가 작업

### DIFF
--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -2,7 +2,7 @@ package com.first.flash.climbing.solution.application;
 
 import com.first.flash.account.member.application.MemberService;
 import com.first.flash.account.member.domain.Member;
-import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.application.dto.SolutionWriteResponseDto;
 import com.first.flash.climbing.solution.application.dto.UnregisteredMemberSolutionCreateRequest;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
@@ -24,7 +24,7 @@ public class SolutionSaveService {
     private final SolutionRepository solutionRepository;
 
     @Transactional
-    public SolutionResponseDto saveSolution(final UUID problemId,
+    public SolutionWriteResponseDto saveSolution(final UUID problemId,
         final SolutionCreateRequestDto createRequestDto) {
         UUID id = AuthUtil.getId();
         Member member = memberService.findById(id);
@@ -34,7 +34,7 @@ public class SolutionSaveService {
             member.getProfileImageUrl());
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
-        return SolutionResponseDto.toDto(savedSolution);
+        return SolutionWriteResponseDto.toDto(savedSolution);
     }
 
     @Transactional
@@ -44,7 +44,7 @@ public class SolutionSaveService {
     }
 
     @Transactional
-    public SolutionResponseDto saveUnregisteredMemberSolution(final UUID problemId,
+    public SolutionWriteResponseDto saveUnregisteredMemberSolution(final UUID problemId,
         final UnregisteredMemberSolutionCreateRequest requestDto) {
         UUID id = AuthUtil.getId();
         Member member = memberService.findById(id);
@@ -54,6 +54,6 @@ public class SolutionSaveService {
             requestDto.profileImageUrl());
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
-        return SolutionResponseDto.toDto(savedSolution);
+        return SolutionWriteResponseDto.toDto(savedSolution);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -3,9 +3,8 @@ package com.first.flash.climbing.solution.application;
 import com.first.flash.account.member.application.BlockService;
 import com.first.flash.climbing.gym.domian.ClimbingGymIdConfirmRequestedEvent;
 import com.first.flash.climbing.problem.domain.ProblemIdConfirmRequestedEvent;
-import com.first.flash.climbing.solution.application.dto.MySolutionsResponseDto;
-import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
+import com.first.flash.climbing.solution.application.dto.SolutionWriteResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsPageResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.Solution;
@@ -69,7 +68,7 @@ public class SolutionService {
     }
 
     @Transactional
-    public SolutionResponseDto updateContent(final Long id,
+    public SolutionWriteResponseDto updateContent(final Long id,
         final SolutionUpdateRequestDto requestDto) {
 
         Solution solution = solutionRepository.findById(id)
@@ -80,7 +79,7 @@ public class SolutionService {
 
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl());
 
-        return SolutionResponseDto.toDto(solution);
+        return SolutionWriteResponseDto.toDto(solution);
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -46,10 +46,7 @@ public class SolutionService {
         Events.raise(ProblemIdConfirmRequestedEvent.of(problemId));
         List<UUID> blockedMembers = blockService.findBlockedMembers();
         List<SolutionResponseDto> solutions = solutionRepository.findAllByProblemId(problemId,
-                                                                    blockedMembers)
-                                                                .stream()
-                                                                .map(SolutionResponseDto::toDto)
-                                                                .toList();
+            AuthUtil.getId(), blockedMembers);
 
         return SolutionsResponseDto.of(solutions);
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -15,6 +15,7 @@ import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeni
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
+import com.first.flash.climbing.solution.infrastructure.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.infrastructure.paging.SolutionCursor;
 import com.first.flash.global.event.Events;
 import com.first.flash.global.util.AuthUtil;

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionWriteResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionWriteResponseDto.java
@@ -1,0 +1,24 @@
+package com.first.flash.climbing.solution.application.dto;
+
+import com.first.flash.climbing.solution.domain.Solution;
+import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
+import com.first.flash.climbing.solution.domain.vo.UploaderDetail;
+import com.first.flash.global.util.AuthUtil;
+import java.util.UUID;
+
+public record SolutionWriteResponseDto(Long id, String uploader, String review, String instagramId,
+                                       String videoUrl, UUID uploaderId, Boolean isUploader,
+                                       String profileImageUrl) {
+
+    public static SolutionWriteResponseDto toDto(final Solution solution) {
+        SolutionDetail solutionDetail = solution.getSolutionDetail();
+        UploaderDetail uploaderDetail = solution.getUploaderDetail();
+        UUID uploaderId = uploaderDetail.getUploaderId();
+        Boolean isUploader = AuthUtil.isSameId(uploaderId);
+
+        return new SolutionWriteResponseDto(solution.getId(), uploaderDetail.getUploader(),
+            solutionDetail.getReview(), uploaderDetail.getInstagramId(),
+            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId(), isUploader,
+            uploaderDetail.getProfileImageUrl());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionsResponseDto.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.application.dto;
 
+import com.first.flash.climbing.solution.infrastructure.dto.SolutionResponseDto;
 import java.util.List;
 
 public record SolutionsResponseDto(List<SolutionResponseDto> solutions,

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
@@ -36,7 +37,7 @@ public class Solution extends BaseEntity {
     private Long optionalWeight;
     @OneToMany(mappedBy = "solution", cascade = CascadeType.ALL, orphanRemoval = true)
     @ToString.Exclude
-    private List<SolutionComment> comments;
+    private List<SolutionComment> comments = new ArrayList<>();
 
     protected Solution(final String uploader, final String review, final String instagramId,
         final String videoUrl, final UUID problemId, final UUID uploaderId,

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionRepository.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.solution.domain;
 
 import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
+import com.first.flash.climbing.solution.infrastructure.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.infrastructure.paging.SolutionCursor;
 import java.util.List;
 import java.util.Optional;
@@ -13,7 +14,8 @@ public interface SolutionRepository {
 
     Optional<Solution> findById(final Long id);
 
-    List<Solution> findAllByProblemId(final UUID problemId, final List<UUID> blockedMembers);
+    List<SolutionResponseDto> findAllByProblemId(final UUID problemId, final UUID memberId,
+        final List<UUID> blockedMembers);
 
     void deleteById(final Long id);
 

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -2,12 +2,12 @@ package com.first.flash.climbing.solution.infrastructure;
 
 import static com.first.flash.climbing.problem.domain.QQueryProblem.queryProblem;
 import static com.first.flash.climbing.solution.domain.QSolution.solution;
+import static com.first.flash.climbing.solution.domain.QSolutionComment.solutionComment;
 
-import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
+import com.first.flash.climbing.solution.infrastructure.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.infrastructure.paging.SolutionCursor;
-import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -24,12 +24,21 @@ public class SolutionQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<Solution> findAllExcludedBlockedMembers(final UUID problemId,
-        final List<UUID> memberIds) {
-        return jpaQueryFactory.selectFrom(solution)
+    public List<SolutionResponseDto> findAllExcludedBlockedMembers(final UUID problemId,
+        final UUID memberId, final List<UUID> memberIds) {
+        return jpaQueryFactory.select(Projections.constructor(SolutionResponseDto.class,
+                                  solution.id, solution.uploaderDetail.uploader, solution.solutionDetail.review,
+                                  solution.uploaderDetail.instagramId, solution.solutionDetail.videoUrl,
+                                  solution.uploaderDetail.uploaderId, solution.uploaderDetail.uploaderId.eq(memberId),
+                                  solution.uploaderDetail.profileImageUrl, solutionComment.count()
+                              ))
+                              .from(solution)
+                              .leftJoin(solutionComment)
+                              .on(solution.id.eq(solutionComment.solution.id))
                               .where(solution.problemId.eq(problemId)
-                                                       .and(solution.uploaderDetail.uploaderId
-                                                           .notIn(memberIds))).fetch();
+                                                       .and(notInBlockedMembers(memberIds)))
+                              .groupBy(solution.id)
+                              .fetch();
     }
 
     public List<MySolutionDto> findByUploaderId(final UUID uploaderId,
@@ -37,15 +46,18 @@ public class SolutionQueryDslRepository {
         final List<String> difficulty) {
         return jpaQueryFactory.select(Projections.constructor(MySolutionDto.class,
                                   solution.id, queryProblem.gymName, queryProblem.sectorName,
-                                  queryProblem.difficultyName, queryProblem.imageUrl, solution.createdAt
+                                  queryProblem.difficultyName, queryProblem.imageUrl, solutionComment.count(),
+                                  solution.createdAt
                               ))
                               .from(solution)
                               .innerJoin(queryProblem)
                               .on(solution.problemId.eq(queryProblem.id))
-                              .fetchJoin()
+                              .leftJoin(solutionComment)
+                              .on(solution.id.eq(solutionComment.solution.id))
                               .where(solution.uploaderDetail.uploaderId.eq(uploaderId),
                                   inGym(gymId), inDifficulties(difficulty),
                                   cursorCondition(prevSolutionCursor))
+                              .groupBy(solution.id)
                               .orderBy(solution.createdAt.desc())
                               .limit(size)
                               .fetch();
@@ -65,17 +77,19 @@ public class SolutionQueryDslRepository {
         return jpaQueryFactory.select(Projections.constructor(DetailSolutionDto.class,
                                   solution.id, solution.solutionDetail.videoUrl, queryProblem.gymName,
                                   queryProblem.sectorName, solution.solutionDetail.review, queryProblem.difficultyName,
-                                  queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
-                              ))
+                                  solutionComment.count(), queryProblem.removalDate, queryProblem.settingDate,
+                                  solution.createdAt))
                               .from(solution)
                               .innerJoin(queryProblem)
                               .on(solution.problemId.eq(queryProblem.id))
+                              .leftJoin(solutionComment)
+                              .on(solution.id.eq(solutionComment.solution.id))
                               .where(solution.id.eq(solutionId))
-                              .fetchJoin()
+                              .groupBy(solution.id)
                               .fetchOne();
     }
 
-    private Predicate cursorCondition(final SolutionCursor prevSolutionCursor) {
+    private BooleanExpression cursorCondition(final SolutionCursor prevSolutionCursor) {
         if (Objects.isNull(prevSolutionCursor) ||
             Objects.isNull(prevSolutionCursor.cursorValue())) {
             return null;
@@ -95,5 +109,12 @@ public class SolutionQueryDslRepository {
             return null;
         }
         return queryProblem.difficultyName.in(difficulty);
+    }
+
+    private BooleanExpression notInBlockedMembers(final List<UUID> memberIds) {
+        if (memberIds.isEmpty()) {
+            return null;
+        }
+        return solution.uploaderDetail.uploaderId.notIn(memberIds);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
 import com.first.flash.climbing.solution.infrastructure.dto.MySolutionDto;
+import com.first.flash.climbing.solution.infrastructure.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.infrastructure.paging.SolutionCursor;
 import java.util.List;
 import java.util.Optional;
@@ -29,13 +30,10 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     }
 
     @Override
-    public List<Solution> findAllByProblemId(final UUID problemId,
-        final List<UUID> blockedMembers) {
-        if (blockedMembers.isEmpty()) {
-            return solutionJpaRepository.findByProblemId(problemId);
-        }
+    public List<SolutionResponseDto> findAllByProblemId(final UUID problemId,
+        final UUID memberId, final List<UUID> blockedMembers) {
         return solutionQueryDslRepository.findAllExcludedBlockedMembers(
-            problemId, blockedMembers);
+            problemId, memberId, blockedMembers);
     }
 
     @Override
@@ -61,7 +59,8 @@ public class SolutionRepositoryImpl implements SolutionRepository {
     }
 
     @Override
-    public List<MySolutionDto> findMySolutions(final UUID myId, final SolutionCursor prevSolutionCursor,
+    public List<MySolutionDto> findMySolutions(final UUID myId,
+        final SolutionCursor prevSolutionCursor,
         final int size, final Long gymId, final List<String> difficulty) {
         return solutionQueryDslRepository.findByUploaderId(myId, prevSolutionCursor, size, gymId,
             difficulty);

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
@@ -4,7 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record DetailSolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
-                                String review, String difficultyName, LocalDate removalDate,
+                                String review, String difficultyName, Long commentsCount, LocalDate removalDate,
                                 LocalDate settingDate, LocalDateTime uploadedAt) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
@@ -3,7 +3,7 @@ package com.first.flash.climbing.solution.infrastructure.dto;
 import java.time.LocalDateTime;
 
 public record MySolutionDto(Long solutionId, String gymName, String sectorName,
-                            String difficultyName, String problemImageUrl,
+                            String difficultyName, String problemImageUrl, Long commentsCount,
                             LocalDateTime uploadedAt) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/SolutionResponseDto.java
@@ -1,25 +1,9 @@
 package com.first.flash.climbing.solution.infrastructure.dto;
 
-import com.first.flash.climbing.solution.domain.Solution;
-import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
-import com.first.flash.climbing.solution.domain.vo.UploaderDetail;
-import com.first.flash.global.util.AuthUtil;
 import java.util.UUID;
 
 public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
                                   String videoUrl, UUID uploaderId, Boolean isUploader,
-                                  String profileImageUrl) {
+                                  String profileImageUrl, Long commentCount) {
 
-    public static SolutionResponseDto toDto(final Solution solution) {
-        SolutionDetail solutionDetail = solution.getSolutionDetail();
-        UploaderDetail uploaderDetail = solution.getUploaderDetail();
-
-        UUID uploaderId = uploaderDetail.getUploaderId();
-        Boolean isUploader = AuthUtil.isSameId(uploaderId);
-
-        return new SolutionResponseDto(solution.getId(), uploaderDetail.getUploader(),
-            solutionDetail.getReview(), uploaderDetail.getInstagramId(),
-            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId(), isUploader,
-            uploaderDetail.getProfileImageUrl());
-    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/SolutionResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/SolutionResponseDto.java
@@ -1,4 +1,4 @@
-package com.first.flash.climbing.solution.application.dto;
+package com.first.flash.climbing.solution.infrastructure.dto;
 
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.vo.SolutionDetail;

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionCommentController.java
@@ -6,7 +6,7 @@ import com.first.flash.climbing.solution.application.dto.SolutionCommentCreateRe
 import com.first.flash.climbing.solution.application.dto.SolutionCommentResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionCommentsResponseDto;
-import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
+import com.first.flash.climbing.solution.infrastructure.dto.SolutionResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;

--- a/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
+++ b/src/main/java/com/first/flash/climbing/solution/ui/SolutionController.java
@@ -2,8 +2,8 @@ package com.first.flash.climbing.solution.ui;
 
 import com.first.flash.climbing.solution.application.SolutionSaveService;
 import com.first.flash.climbing.solution.application.SolutionService;
-import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
+import com.first.flash.climbing.solution.application.dto.SolutionWriteResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsPageResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.application.dto.UnregisteredMemberSolutionCreateRequest;
@@ -92,7 +92,7 @@ public class SolutionController {
     @Operation(summary = "해설 업로드", description = "특정 문제에 대한 해설 업로드")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "성공적으로 해설을 업로드함",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionResponseDto.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionWriteResponseDto.class))),
         @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "요청값 누락", value = "{\"videoUrl\": \"비디오 URL은 필수입니다.\"}"),
@@ -103,7 +103,7 @@ public class SolutionController {
             }))
     })
     @PostMapping("problems/{problemId}/solutions")
-    public ResponseEntity<SolutionResponseDto> createSolution(@PathVariable final UUID problemId,
+    public ResponseEntity<SolutionWriteResponseDto> createSolution(@PathVariable final UUID problemId,
         @Valid @RequestBody final SolutionCreateRequestDto solutionCreateRequestDto) {
 
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -115,7 +115,7 @@ public class SolutionController {
     @Operation(summary = "없는 유저의 영상으로 해설 업로드", description = "없는 유저의 영상으로 해설 업로드")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "성공적으로 해설을 업로드함",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionResponseDto.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionWriteResponseDto.class))),
         @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "요청값 누락", value = "{\"videoUrl\": \"비디오 URL은 필수입니다.\"}"),
@@ -126,7 +126,7 @@ public class SolutionController {
             }))
     })
     @PostMapping("admin/problems/{problemId}/solutions")
-    public ResponseEntity<SolutionResponseDto> createUnregisteredMemberSolution(
+    public ResponseEntity<SolutionWriteResponseDto> createUnregisteredMemberSolution(
         @PathVariable final UUID problemId,
         @Valid @RequestBody final UnregisteredMemberSolutionCreateRequest createRequestDto) {
 
@@ -139,7 +139,7 @@ public class SolutionController {
     @Operation(summary = "해설 수정", description = "특정 해설 정보 수정")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "성공적으로 해설을 수정함",
-            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionResponseDto.class))),
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SolutionWriteResponseDto.class))),
         @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "요청값 누락", value = "{\"videoUrl\": \"비디오 URL은 필수입니다.\"}"),
@@ -154,7 +154,7 @@ public class SolutionController {
             }))
     })
     @PatchMapping("/solutions/{solutionId}")
-    public ResponseEntity<SolutionResponseDto> updateSolution(@PathVariable Long solutionId,
+    public ResponseEntity<SolutionWriteResponseDto> updateSolution(@PathVariable Long solutionId,
         @Valid @RequestBody final SolutionUpdateRequestDto solutionUpdateRequestDto) {
         return ResponseEntity.status(HttpStatus.OK)
                              .body(


### PR DESCRIPTION
## 요약
- 해설 조회 응답 dto에 댓글 개수 추가
- 해설 조회 응답 dto와 쓰기 응답 dto 분리

## 내용
### N+1 문제 해결
현재 Solution 엔티티를 보면, Comment와 1:N 연관관계 매핑이 되어있습니다.
```java
@OneToMany(mappedBy = "solution", cascade = CascadeType.ALL, orphanRemoval = true)
    @ToString.Exclude
    private List<SolutionComment> comments = new ArrayList<>();
```
특정 solution의 댓글 수를 가져오는 가장 간단한 방법은 comments.size()로 가져오는 방법일 것입니다.
하지만 그렇게 되면 여러 해설의 댓글을 가져올 때 N+1 문제가 생깁니다.
![image](https://github.com/user-attachments/assets/d0958fd1-7406-4fdd-a08e-e709aae23a78)
가져오는 해설만큼 댓글 개수 요청 쿼리를 보내는 것을 볼 수 있습니다.

이를 해결하기 위해 solution을 가져올 때 comment를 join해서 그 개수를 구하는 방법을 사용했습니다.
```java
public List<SolutionResponseDto> findAllExcludedBlockedMembers(final UUID problemId,
        final UUID memberId, final List<UUID> memberIds) {
        return jpaQueryFactory.select(Projections.constructor(SolutionResponseDto.class,
                                  solution.id, solution.uploaderDetail.uploader, solution.solutionDetail.review,
                                  solution.uploaderDetail.instagramId, solution.solutionDetail.videoUrl,
                                  solution.uploaderDetail.uploaderId, solution.uploaderDetail.uploaderId.eq(memberId),
                                  solution.uploaderDetail.profileImageUrl, solutionComment.count()
                              ))
                              .from(solution)
                              .leftJoin(solutionComment)
                              .on(solution.id.eq(solutionComment.solution.id))
                              .where(solution.problemId.eq(problemId)
                                                       .and(notInBlockedMembers(memberIds)))
                              .groupBy(solution.id)
                              .fetch();
    }
```
개선된 코드의 결과는 아래와 같습니다.
![image](https://github.com/user-attachments/assets/0f204ec6-bcbd-43c8-a0a5-f6c20cb2fe43)
이제 여러 solution을 가져오더라도 한 번의 쿼리로 댓글 수까지 가져오는 것을 볼 수 있습니다.

### 조회 응답 dto와 쓰기 응답 dto 구분
조회를 할 때만 dto가 댓글의 개수를 포함합니다. 따라서 조회와 쓰기의 응답 dto를 구분했습니다.
```java
public record SolutionWriteResponseDto(Long id, String uploader, String review, String instagramId,
                                       String videoUrl, UUID uploaderId, Boolean isUploader,
                                       String profileImageUrl){
}
```
위는 저장, 수정할 때 solution의 응답 dto입니다.

조회할 때의 상황은
- 내가 푼 해설 조회
- 특정 문제에 대한 해설 조회
- 특정 해설 조회
3가지 입니다.

_MySolutionDto_
```java
public record MySolutionDto(Long solutionId, String gymName, String sectorName,
                            String difficultyName, String problemImageUrl, Long commentsCount,
                            LocalDateTime uploadedAt) {

}
```
_DetailSolutionDto_
```java
public record DetailSolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
                                String review, String difficultyName, Long commentsCount, LocalDate removalDate,
                                LocalDate settingDate, LocalDateTime uploadedAt) {

}
```
_SolutionResponseDto_
```java
public record SolutionResponseDto(Long id, String uploader, String review, String instagramId,
                                  String videoUrl, UUID uploaderId, Boolean isUploader,
                                  String profileImageUrl, Long commentCount) {

}
```
3가지 상황에 대해 위처럼 조회 dto들을 수정했습니다.

