### PR TITLE
체감 난이도 투표 및 꿀 문제 표시

### DIFF
--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -4,6 +4,7 @@ import com.first.flash.climbing.problem.domain.ProblemIdConfirmRequestedEvent;
 import com.first.flash.climbing.sector.domain.SectorExpiredEvent;
 import com.first.flash.climbing.sector.domain.SectorInfoUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
+import com.first.flash.climbing.solution.domain.PerceivedDifficultySetEvent;
 import com.first.flash.climbing.solution.domain.SolutionDeletedEvent;
 import com.first.flash.climbing.solution.domain.SolutionSavedEvent;
 import lombok.RequiredArgsConstructor;
@@ -53,5 +54,11 @@ public class ProblemEventHandler {
     @Transactional
     public void confirmProblemId(final ProblemIdConfirmRequestedEvent event) {
         problemReadService.findProblemById(event.getProblemId());
+    }
+
+    @EventListener
+    @Transactional
+    public void updatePerceivedDifficulty(final PerceivedDifficultySetEvent event) {
+        System.out.println("PerceivedDifficultySetEvent event called!");
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -40,7 +40,7 @@ public class ProblemEventHandler {
     @EventListener
     @Transactional
     public void updateProblemDeletedSolutionInfo(final SolutionDeletedEvent event) {
-        problemsService.updateProblemDeletedSolutionInfo(event.getProblemId());
+        problemsService.updateProblemDeletedSolutionInfo(event.getProblemId(), event.getPerceivedDifficulty());
     }
 
     @EventListener

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -59,6 +59,6 @@ public class ProblemEventHandler {
     @EventListener
     @Transactional
     public void updatePerceivedDifficulty(final PerceivedDifficultySetEvent event) {
-        problemsService.updatePerceivedDifficulty(event.getProblemId(), event.getPerceivedDifficulty());
+        problemsService.addPerceivedDifficulty(event.getProblemId(), event.getPerceivedDifficulty());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -59,6 +59,6 @@ public class ProblemEventHandler {
     @EventListener
     @Transactional
     public void updatePerceivedDifficulty(final PerceivedDifficultySetEvent event) {
-        System.out.println("PerceivedDifficultySetEvent event called!");
+        problemsService.updatePerceivedDifficulty(event.getProblemId(), event.getPerceivedDifficulty());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemReadService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemReadService.java
@@ -31,8 +31,8 @@ public class ProblemReadService {
     private final ProblemRepository problemRepository;
 
     public ProblemsResponseDto findAll(final Long gymId, final String cursor,
-        final String sortByRequest, final Integer size,
-        final List<String> difficulty, final List<String> sector, final Boolean hasSolution) {
+        final String sortByRequest, final Integer size, final List<String> difficulty,
+        final List<String> sector, final Boolean hasSolution, final Boolean isHoney) {
         ProblemCursor prevProblemCursor = ProblemCursor.decode(cursor);
         ProblemSortBy problemSortBy = ProblemSortBy.from(sortByRequest);
 
@@ -40,7 +40,7 @@ public class ProblemReadService {
 
         List<QueryProblem> queryProblems = queryProblemRepository.findAll(prevProblemCursor,
             problemSortBy, size,
-            gymId, difficulty, sector, hasSolution);
+            gymId, difficulty, sector, hasSolution, isHoney);
         String nextCursor = getNextCursor(problemSortBy, size, queryProblems);
         return ProblemsResponseDto.of(queryProblems, nextCursor);
     }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -47,4 +47,9 @@ public class ProblemsService {
         final LocalDate settingDate) {
         queryProblemRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate);
     }
+
+    @Transactional
+    public void updatePerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
+        queryProblemRepository.updatePerceivedDifficulty(problemId, perceivedDifficulty);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.problem.application;
 
+import com.first.flash.climbing.problem.application.dto.ProblemDetailResponseDto;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
 import com.first.flash.climbing.problem.domain.QueryProblem;
 import com.first.flash.climbing.problem.domain.QueryProblemRepository;
@@ -53,5 +54,12 @@ public class ProblemsService {
     public void addPerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
         queryProblem.addPerceivedDifficulty(perceivedDifficulty);
+    }
+
+    @Transactional
+    public ProblemDetailResponseDto setPerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
+        QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
+        queryProblem.setPerceivedDifficulty(perceivedDifficulty);
+        return ProblemDetailResponseDto.of(queryProblem);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -50,7 +50,7 @@ public class ProblemsService {
     }
 
     @Transactional
-    public void updatePerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
+    public void addPerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
         queryProblem.addPerceivedDifficulty(perceivedDifficulty);
     }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -37,9 +37,10 @@ public class ProblemsService {
     }
 
     @Transactional
-    public void updateProblemDeletedSolutionInfo(final UUID problemId) {
+    public void updateProblemDeletedSolutionInfo(final UUID problemId, final Integer perceivedDifficulty) {
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
         queryProblem.decrementSolutionCount();
+        queryProblemRepository.updatePerceivedDifficulty(problemId, perceivedDifficulty);
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -40,7 +40,7 @@ public class ProblemsService {
     public void updateProblemDeletedSolutionInfo(final UUID problemId, final Integer perceivedDifficulty) {
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
         queryProblem.decrementSolutionCount();
-        queryProblemRepository.updatePerceivedDifficulty(problemId, perceivedDifficulty);
+        queryProblem.subtractPerceivedDifficulty(perceivedDifficulty);
     }
 
     @Transactional
@@ -51,6 +51,7 @@ public class ProblemsService {
 
     @Transactional
     public void updatePerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
-        queryProblemRepository.updatePerceivedDifficulty(problemId, perceivedDifficulty);
+        QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
+        queryProblem.addPerceivedDifficulty(perceivedDifficulty);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
@@ -7,13 +7,13 @@ import java.util.UUID;
 public record ProblemDetailResponseDto(UUID id, String sector, String difficulty,
                                        LocalDate settingDate, LocalDate removalDate,
                                        boolean isFakeRemovalDate, boolean hasSolution,
-                                       String imageUrl, String gymName, String imageSource) {
+                                       String imageUrl, String gymName, String imageSource, Boolean isHoney) {
 
     public static ProblemDetailResponseDto of(final QueryProblem queryProblem) {
         return new ProblemDetailResponseDto(queryProblem.getId(), queryProblem.getSectorName(),
             queryProblem.getDifficultyName(), queryProblem.getSettingDate(),
             queryProblem.getRemovalDate(), queryProblem.getIsFakeRemovalDate(),
             queryProblem.getHasSolution(), queryProblem.getImageUrl(), queryProblem.getGymName(),
-            queryProblem.getImageSource());
+            queryProblem.getImageSource(), queryProblem.isHoney());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemPerceivedDifficultyRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemPerceivedDifficultyRequestDto.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.problem.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ProblemPerceivedDifficultyRequestDto(
+    @NotNull(message = "변경할 체감 난이도 수치는 필수입니다.") Integer perceivedDifficulty) {
+
+}

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemResponseDto.java
@@ -5,12 +5,12 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 public record ProblemResponseDto(UUID id, String sector, String difficulty, LocalDate settingDate,
-                                 LocalDate removalDate, boolean hasSolution, String imageUrl) {
+                                 LocalDate removalDate, boolean hasSolution, String imageUrl, Boolean isHoney) {
 
     public static ProblemResponseDto toDto(QueryProblem queryProblem) {
         return new ProblemResponseDto(queryProblem.getId(), queryProblem.getSectorName(),
             queryProblem.getDifficultyName(), queryProblem.getSettingDate(),
             queryProblem.getRemovalDate(), queryProblem.getHasSolution(),
-            queryProblem.getImageUrl());
+            queryProblem.getImageUrl(), queryProblem.isHoney());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
@@ -16,6 +16,7 @@ public class ProblemsCreateService {
     private static final Boolean DEFAULT_HAS_SOLUTION = false;
     private static final Integer INITIAL_SOLUTION_COUNT = 0;
     private static final Long INITIAL_RECOMMENDATION_VALUE = 0L;
+    private static final Integer INITIAL_PERCEIVED_DIFFICULTY_VALUE = 0;
 
     private final UUIDGenerator uuidGenerator;
 
@@ -36,6 +37,7 @@ public class ProblemsCreateService {
                            .views(problem.getViews())
                            .isExpired(problem.getIsExpired())
                            .hasSolution(DEFAULT_HAS_SOLUTION)
+                           .perceivedDifficulty(INITIAL_PERCEIVED_DIFFICULTY_VALUE)
                            .recommendationValue(INITIAL_RECOMMENDATION_VALUE)
                            .solutionCount(INITIAL_SOLUTION_COUNT)
                            .isFakeRemovalDate(sector.getRemovalInfo().getIsFakeRemovalDate())

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -42,6 +42,7 @@ public class QueryProblem {
     private Integer views;
     private Boolean isExpired;
     private Integer solutionCount;
+    private Integer perceivedDifficulty;
     private Long recommendationValue;
     private Boolean hasSolution;
     private Boolean isFakeRemovalDate;

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 @Entity
@@ -42,6 +43,7 @@ public class QueryProblem {
     private Integer views;
     private Boolean isExpired;
     private Integer solutionCount;
+    @Setter
     private Integer perceivedDifficulty;
     private Long recommendationValue;
     private Boolean hasSolution;

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -90,6 +90,10 @@ public class QueryProblem {
         perceivedDifficulty -= value;
     }
 
+    public Boolean isHoney() {
+        return perceivedDifficulty < 0;
+    }
+
     private void enableSolution() {
         if (!hasSolution) {
             hasSolution = true;

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -80,6 +80,14 @@ public class QueryProblem {
         calculateRecommendationValue();
     }
 
+    public void addPerceivedDifficulty(final Integer value) {
+        perceivedDifficulty += value;
+    }
+
+    public void subtractPerceivedDifficulty(final Integer value) {
+        perceivedDifficulty -= value;
+    }
+
     private void enableSolution() {
         if (!hasSolution) {
             hasSolution = true;

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -15,7 +15,7 @@ public interface QueryProblemRepository {
 
     List<QueryProblem> findAll(final ProblemCursor preProblemCursor, final ProblemSortBy problemSortBy, final int size,
         final Long gymId, final List<String> difficulty, final List<String> sector,
-        final Boolean hasSolution);
+        final Boolean hasSolution, final Boolean isHoney);
 
     void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate);
 

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -23,6 +23,4 @@ public interface QueryProblemRepository {
 
     void updateQueryProblemInfo(final Long sectorId, final String sectorName,
         final LocalDate settingDate);
-
-    void updatePerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -23,4 +23,6 @@ public interface QueryProblemRepository {
 
     void updateQueryProblemInfo(final Long sectorId, final String sectorName,
         final LocalDate settingDate);
+
+    void updatePerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -59,6 +59,13 @@ public class QueryProblemQueryDslRepository {
                     .execute();
     }
 
+    public void updatePerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
+        queryFactory.update(queryProblem)
+                    .set(queryProblem.perceivedDifficulty, queryProblem.perceivedDifficulty.add(perceivedDifficulty))
+                    .where(queryProblem.id.eq(problemId))
+                    .execute();
+    }
+
     private BooleanExpression inGym(final Long gymId) {
         return queryProblem.gymId.eq(gymId);
     }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -25,11 +25,11 @@ public class QueryProblemQueryDslRepository {
 
     public List<QueryProblem> findAll(final ProblemCursor prevProblemCursor, final ProblemSortBy problemSortBy, final int size,
         final Long gymId, final List<String> difficulty, final List<String> sector,
-        final Boolean hasSolution) {
+        final Boolean hasSolution, final Boolean isHoney) {
         return queryFactory
             .selectFrom(queryProblem)
             .where(notExpired(), cursorCondition(prevProblemCursor), inGym(gymId), inSectors(sector),
-                inDifficulties(difficulty), hasSolution(hasSolution))
+                inDifficulties(difficulty), hasSolution(hasSolution), isHoneyCondition(isHoney))
             .orderBy(sortItem(problemSortBy), queryProblem.id.desc())
             .limit(size)
             .fetch();
@@ -61,6 +61,13 @@ public class QueryProblemQueryDslRepository {
 
     private BooleanExpression inGym(final Long gymId) {
         return queryProblem.gymId.eq(gymId);
+    }
+
+    private BooleanExpression isHoneyCondition(final Boolean isHoney) {
+        if (Boolean.TRUE.equals(isHoney)) {
+            return queryProblem.perceivedDifficulty.lt(0);
+        }
+        return null;
     }
 
     private BooleanExpression cursorCondition(final ProblemCursor prevProblemCursor) {

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -59,13 +59,6 @@ public class QueryProblemQueryDslRepository {
                     .execute();
     }
 
-    public void updatePerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
-        queryFactory.update(queryProblem)
-                    .set(queryProblem.perceivedDifficulty, queryProblem.perceivedDifficulty.add(perceivedDifficulty))
-                    .where(queryProblem.id.eq(problemId))
-                    .execute();
-    }
-
     private BooleanExpression inGym(final Long gymId) {
         return queryProblem.gymId.eq(gymId);
     }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -51,4 +51,9 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
         final LocalDate settingDate) {
         queryProblemQueryDslRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate);
     }
+
+    @Override
+    public void updatePerceivedDifficulty(UUID problemId, Integer perceivedDifficulty) {
+        queryProblemQueryDslRepository.updatePerceivedDifficulty(problemId, perceivedDifficulty);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -51,9 +51,4 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
         final LocalDate settingDate) {
         queryProblemQueryDslRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate);
     }
-
-    @Override
-    public void updatePerceivedDifficulty(UUID problemId, Integer perceivedDifficulty) {
-        queryProblemQueryDslRepository.updatePerceivedDifficulty(problemId, perceivedDifficulty);
-    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -31,9 +31,9 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
     @Override
     public List<QueryProblem> findAll(final ProblemCursor prevProblemCursor, final ProblemSortBy problemSortBy, final int size,
         final Long gymId, final List<String> difficulty, final List<String> sector,
-        final Boolean hasSolution) {
+        final Boolean hasSolution, final Boolean isHoney) {
         return queryProblemQueryDslRepository.findAll(prevProblemCursor, problemSortBy, size,
-            gymId, difficulty, sector, hasSolution);
+            gymId, difficulty, sector, hasSolution, isHoney);
     }
 
     @Override

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -82,10 +82,11 @@ public class ProblemController {
         @RequestParam(defaultValue = DEFAULT_SIZE, required = false) final int size,
         @RequestParam(required = false) final List<String> difficulty,
         @RequestParam(required = false) final List<String> sector,
-        @RequestParam(name = "has-solution", required = false) final Boolean hasSolution) {
+        @RequestParam(name = "has-solution", required = false) final Boolean hasSolution,
+        @RequestParam(name = "is-honey", required = false) final Boolean isHoney) {
         return ResponseEntity.ok(
             problemReadService.findAll(gymId, cursor, sortBy, size, difficulty, sector,
-                hasSolution));
+                hasSolution, isHoney));
     }
 
     @Operation(summary = "문제 단건 조회", description = "특정 문제의 정보 조회")

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -103,6 +103,19 @@ public class ProblemController {
         return ResponseEntity.ok(problemReadService.viewProblems(problemId));
     }
 
+    @Operation(summary = "문제 체감 난이도 수정", description = "특정 문제의 체감 난이도 수정")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 문제 정보 수정함",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = ProblemDetailResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "요청값 누락", value = "{\"perceivedDifficulty\": \"변경할 체감 난이도 수치는 필수입니다.\"}")
+            })),
+        @ApiResponse(responseCode = "404", description = "리소스를 찾을 수 없음",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "문제 없음", value = "{\"error\": \"아이디가 0190c558-9063-7050-b4fc-eb421e3236b3인 문제를 찾을 수 없습니다.\"}")
+            }))
+    })
     @PatchMapping("/admin/problems/{problemId}/perceivedDifficulty")
     public ResponseEntity<ProblemDetailResponseDto> changePerceivedDifficulty(
         @PathVariable final UUID problemId,

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -2,8 +2,10 @@ package com.first.flash.climbing.problem.ui;
 
 import com.first.flash.climbing.problem.application.ProblemReadService;
 import com.first.flash.climbing.problem.application.ProblemsSaveService;
+import com.first.flash.climbing.problem.application.ProblemsService;
 import com.first.flash.climbing.problem.application.dto.ProblemCreateResponseDto;
 import com.first.flash.climbing.problem.application.dto.ProblemDetailResponseDto;
+import com.first.flash.climbing.problem.application.dto.ProblemPerceivedDifficultyRequestDto;
 import com.first.flash.climbing.problem.application.dto.ProblemsResponseDto;
 import com.first.flash.climbing.problem.domain.dto.ProblemCreateRequestDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -20,6 +22,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -36,6 +39,7 @@ public class ProblemController {
 
     private final ProblemsSaveService problemsSaveService;
     private final ProblemReadService problemReadService;
+    private final ProblemsService problemsService;
 
     @Operation(summary = "문제 생성", description = "특정 섹터에 문제 생성")
     @ApiResponses(value = {
@@ -97,5 +101,12 @@ public class ProblemController {
     public ResponseEntity<ProblemDetailResponseDto> findProblemById(
         @PathVariable final UUID problemId) {
         return ResponseEntity.ok(problemReadService.viewProblems(problemId));
+    }
+
+    @PatchMapping("/admin/problems/{problemId}/perceivedDifficulty")
+    public ResponseEntity<ProblemDetailResponseDto> changePerceivedDifficulty(
+        @PathVariable final UUID problemId,
+        @Valid @RequestBody final ProblemPerceivedDifficultyRequestDto requestDto) {
+        return ResponseEntity.ok(problemsService.setPerceivedDifficulty(problemId, requestDto.perceivedDifficulty()));
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -31,11 +31,11 @@ public class SolutionSaveService {
         UUID id = AuthUtil.getId();
         Member member = memberService.findById(id);
 
-        Integer perceivedDifficulty = createRequestDto.perceivedDifficulty().getValue();
+        PerceivedDifficulty perceivedDifficulty = createRequestDto.perceivedDifficulty();
         Solution solution = Solution.of(member.getNickName(), createRequestDto.review(),
             member.getInstagramId(), createRequestDto.videoUrl(), problemId, member.getId(),
             member.getProfileImageUrl(), perceivedDifficulty);
-        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty));
+        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty.getValue()));
 
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
@@ -54,13 +54,15 @@ public class SolutionSaveService {
         UUID id = AuthUtil.getId();
         Member member = memberService.findById(id);
 
-        Integer perceivedDifficulty = requestDto.perceivedDifficulty().getValue();
+        PerceivedDifficulty perceivedDifficulty = requestDto.perceivedDifficulty();
         Solution solution = Solution.of(requestDto.nickName(), requestDto.review(),
             requestDto.instagramId(), requestDto.videoUrl(), problemId, member.getId(),
             requestDto.profileImageUrl(), perceivedDifficulty);
+
         Solution savedSolution = solutionRepository.save(solution);
-        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty));
+        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty.getValue()));
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
+
         return SolutionResponseDto.toDto(savedSolution);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -4,6 +4,7 @@ import com.first.flash.account.member.application.MemberService;
 import com.first.flash.account.member.domain.Member;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.UnregisteredMemberSolutionCreateRequest;
+import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.domain.SolutionSavedEvent;
@@ -29,9 +30,11 @@ public class SolutionSaveService {
         UUID id = AuthUtil.getId();
         Member member = memberService.findById(id);
 
+        Integer perceivedDifficulty = createRequestDto.perceivedDifficulty().getValue();
         Solution solution = Solution.of(member.getNickName(), createRequestDto.review(),
             member.getInstagramId(), createRequestDto.videoUrl(), problemId, member.getId(),
-            member.getProfileImageUrl());
+            member.getProfileImageUrl(), perceivedDifficulty);
+
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
         return SolutionResponseDto.toDto(savedSolution);
@@ -49,9 +52,10 @@ public class SolutionSaveService {
         UUID id = AuthUtil.getId();
         Member member = memberService.findById(id);
 
+        Integer perceivedDifficulty = requestDto.perceivedDifficulty().getValue();
         Solution solution = Solution.of(requestDto.nickName(), requestDto.review(),
             requestDto.instagramId(), requestDto.videoUrl(), problemId, member.getId(),
-            requestDto.profileImageUrl());
+            requestDto.profileImageUrl(), perceivedDifficulty);
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
         return SolutionResponseDto.toDto(savedSolution);

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -5,6 +5,7 @@ import com.first.flash.account.member.domain.Member;
 import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.UnregisteredMemberSolutionCreateRequest;
 import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
+import com.first.flash.climbing.solution.domain.PerceivedDifficultySetEvent;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
 import com.first.flash.climbing.solution.domain.SolutionSavedEvent;
@@ -34,6 +35,7 @@ public class SolutionSaveService {
         Solution solution = Solution.of(member.getNickName(), createRequestDto.review(),
             member.getInstagramId(), createRequestDto.videoUrl(), problemId, member.getId(),
             member.getProfileImageUrl(), perceivedDifficulty);
+        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty));
 
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
@@ -57,6 +59,7 @@ public class SolutionSaveService {
             requestDto.instagramId(), requestDto.videoUrl(), problemId, member.getId(),
             requestDto.profileImageUrl(), perceivedDifficulty);
         Solution savedSolution = solutionRepository.save(solution);
+        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty));
         Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
         return SolutionResponseDto.toDto(savedSolution);
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -98,7 +98,9 @@ public class SolutionService {
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
         validateUploader(solution);
         solutionRepository.deleteById(id);
-        Events.raise(SolutionDeletedEvent.of(solution.getProblemId()));
+
+        Integer perceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty() * -1;
+        Events.raise(SolutionDeletedEvent.of(solution.getProblemId(), perceivedDifficulty));
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -77,7 +77,7 @@ public class SolutionService {
 
         PerceivedDifficulty newPerceivedDifficulty = requestDto.perceivedDifficulty();
         PerceivedDifficulty oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
-        int difficultyDifference = calculateDifficultyDifference(oldPerceivedDifficulty, newPerceivedDifficulty);
+        int difficultyDifference = newPerceivedDifficulty.calculateDifferenceFrom(oldPerceivedDifficulty);
 
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), newPerceivedDifficulty);
 
@@ -123,9 +123,5 @@ public class SolutionService {
         if (!AuthUtil.isSameId(uploaderId)) {
             throw new SolutionAccessDeniedException();
         }
-    }
-
-    private int calculateDifficultyDifference(PerceivedDifficulty oldPerceivedDifficulty, PerceivedDifficulty newPerceivedDifficulty) {
-        return newPerceivedDifficulty.getValue() - oldPerceivedDifficulty.getValue();
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -8,6 +8,7 @@ import com.first.flash.climbing.solution.application.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsPageResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
+import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionDeletedEvent;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
@@ -77,7 +78,8 @@ public class SolutionService {
         UUID uploaderId = solution.getUploaderDetail().getUploaderId();
         validateUploader(uploaderId);
 
-        solution.updateContentInfo(requestDto.review(), requestDto.videoUrl());
+        Integer perceivedDifficulty = requestDto.perceivedDifficulty().getValue();
+        solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), perceivedDifficulty);
 
         return SolutionResponseDto.toDto(solution);
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -80,7 +80,7 @@ public class SolutionService {
 
         Integer newPerceivedDifficulty = requestDto.perceivedDifficulty().getValue();
         Integer oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
-        int difficultyDifference = calculateDifficultyDifference(newPerceivedDifficulty, oldPerceivedDifficulty);
+        int difficultyDifference = calculateDifficultyDifference(oldPerceivedDifficulty, newPerceivedDifficulty);
 
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), newPerceivedDifficulty);
 
@@ -99,7 +99,7 @@ public class SolutionService {
         validateUploader(solution);
         solutionRepository.deleteById(id);
 
-        Integer perceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty() * -1;
+        Integer perceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
         Events.raise(SolutionDeletedEvent.of(solution.getProblemId(), perceivedDifficulty));
     }
 

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -78,8 +78,8 @@ public class SolutionService {
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
         validateUploader(solution);
 
-        Integer newPerceivedDifficulty = requestDto.perceivedDifficulty().getValue();
-        Integer oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
+        PerceivedDifficulty newPerceivedDifficulty = requestDto.perceivedDifficulty();
+        PerceivedDifficulty oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
         int difficultyDifference = calculateDifficultyDifference(oldPerceivedDifficulty, newPerceivedDifficulty);
 
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), newPerceivedDifficulty);
@@ -99,8 +99,8 @@ public class SolutionService {
         validateUploader(solution);
         solutionRepository.deleteById(id);
 
-        Integer perceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
-        Events.raise(SolutionDeletedEvent.of(solution.getProblemId(), perceivedDifficulty));
+        PerceivedDifficulty perceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
+        Events.raise(SolutionDeletedEvent.of(solution.getProblemId(), perceivedDifficulty.getValue()));
     }
 
     @Transactional
@@ -128,7 +128,7 @@ public class SolutionService {
         }
     }
 
-    private int calculateDifficultyDifference(Integer oldPerceivedDifficulty, Integer newPerceivedDifficulty) {
-        return newPerceivedDifficulty - oldPerceivedDifficulty;
+    private int calculateDifficultyDifference(PerceivedDifficulty oldPerceivedDifficulty, PerceivedDifficulty newPerceivedDifficulty) {
+        return newPerceivedDifficulty.getValue() - oldPerceivedDifficulty.getValue();
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -80,9 +80,16 @@ public class SolutionService {
         UUID uploaderId = solution.getUploaderDetail().getUploaderId();
         validateUploader(uploaderId);
 
-        Integer perceivedDifficulty = requestDto.perceivedDifficulty().getValue();
-        solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), perceivedDifficulty);
-        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty));
+        Integer newPerceivedDifficulty = requestDto.perceivedDifficulty().getValue();
+        Integer oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
+        int difficultyDifference = newPerceivedDifficulty - oldPerceivedDifficulty;
+
+        solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), newPerceivedDifficulty);
+
+        Events.raise(PerceivedDifficultySetEvent.of(
+            solution.getProblemId(),
+            difficultyDifference
+        ));
 
         return SolutionResponseDto.toDto(solution);
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -76,9 +76,7 @@ public class SolutionService {
 
         Solution solution = solutionRepository.findById(id)
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
-
-        UUID uploaderId = solution.getUploaderDetail().getUploaderId();
-        validateUploader(uploaderId);
+        validateUploader(solution);
 
         Integer newPerceivedDifficulty = requestDto.perceivedDifficulty().getValue();
         Integer oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
@@ -98,8 +96,7 @@ public class SolutionService {
     public void deleteSolution(final Long id) {
         Solution solution = solutionRepository.findById(id)
                                               .orElseThrow(() -> new SolutionNotFoundException(id));
-        UUID uploaderId = solution.getUploaderDetail().getUploaderId();
-        validateUploader(uploaderId);
+        validateUploader(solution);
         solutionRepository.deleteById(id);
         Events.raise(SolutionDeletedEvent.of(solution.getProblemId()));
     }
@@ -122,7 +119,8 @@ public class SolutionService {
         return solutions.size() != size;
     }
 
-    private void validateUploader(final UUID uploaderId) {
+    private void validateUploader(final Solution solution) {
+        UUID uploaderId = solution.getUploaderDetail().getUploaderId();
         if (!AuthUtil.isSameId(uploaderId)) {
             throw new SolutionAccessDeniedException();
         }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -80,7 +80,7 @@ public class SolutionService {
 
         Integer newPerceivedDifficulty = requestDto.perceivedDifficulty().getValue();
         Integer oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
-        int difficultyDifference = newPerceivedDifficulty - oldPerceivedDifficulty;
+        int difficultyDifference = calculateDifficultyDifference(newPerceivedDifficulty, oldPerceivedDifficulty);
 
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), newPerceivedDifficulty);
 
@@ -124,5 +124,9 @@ public class SolutionService {
         if (!AuthUtil.isSameId(uploaderId)) {
             throw new SolutionAccessDeniedException();
         }
+    }
+
+    private int calculateDifficultyDifference(Integer oldPerceivedDifficulty, Integer newPerceivedDifficulty) {
+        return newPerceivedDifficulty - oldPerceivedDifficulty;
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -9,9 +9,11 @@ import com.first.flash.climbing.solution.application.dto.SolutionUpdateRequestDt
 import com.first.flash.climbing.solution.application.dto.SolutionsPageResponseDto;
 import com.first.flash.climbing.solution.application.dto.SolutionsResponseDto;
 import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
+import com.first.flash.climbing.solution.domain.PerceivedDifficultySetEvent;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionDeletedEvent;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
+import com.first.flash.climbing.solution.domain.SolutionSavedEvent;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeniedException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import com.first.flash.climbing.solution.infrastructure.dto.DetailSolutionDto;
@@ -80,6 +82,7 @@ public class SolutionService {
 
         Integer perceivedDifficulty = requestDto.perceivedDifficulty().getValue();
         solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), perceivedDifficulty);
+        Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(), perceivedDifficulty));
 
         return SolutionResponseDto.toDto(solution);
     }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionUpdateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionUpdateRequestDto.java
@@ -1,10 +1,13 @@
 package com.first.flash.climbing.solution.application.dto;
 
+import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
+import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 public record SolutionUpdateRequestDto(
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
-    @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review) {
+    @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review,
+    @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionUpdateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionUpdateRequestDto.java
@@ -3,11 +3,13 @@ package com.first.flash.climbing.solution.application.dto;
 import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SolutionUpdateRequestDto(
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
     @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review,
+    @NotNull(message = "체감 난이도는 필수입니다.")
     @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
@@ -1,11 +1,14 @@
 package com.first.flash.climbing.solution.application.dto;
 
+import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
+import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
 
 public record UnregisteredMemberSolutionCreateRequest(
     @NotEmpty(message = "닉네임은 필수입니다.") String nickName,
     @NotEmpty(message = "인스타그램 아이디는 필수입니다.") String instagramId,
     String review, String profileImageUrl,
-    @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl) {
+    @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
+    @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
@@ -3,12 +3,14 @@ package com.first.flash.climbing.solution.application.dto;
 import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record UnregisteredMemberSolutionCreateRequest(
     @NotEmpty(message = "닉네임은 필수입니다.") String nickName,
     @NotEmpty(message = "인스타그램 아이디는 필수입니다.") String instagramId,
     String review, String profileImageUrl,
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
+    @NotNull(message = "체감 난이도는 필수입니다.")
     @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
@@ -4,23 +4,21 @@ import lombok.AllArgsConstructor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
 
 @AllArgsConstructor
+@Getter
 public enum PerceivedDifficulty {
     EASY(-1, "쉬움"),
     NORMAL(0, "보통"),
     HARD(1, "어려움");
 
-    private final int value;
+    private final Integer value;
     private final String label;
 
     @JsonValue
     public String getLabel() {
         return label;
-    }
-
-    public Integer getValue() {
-        return value;
     }
 
     @JsonCreator

--- a/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
@@ -1,0 +1,35 @@
+package com.first.flash.climbing.solution.domain;
+
+import lombok.AllArgsConstructor;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@AllArgsConstructor
+public enum PerceivedDifficulty {
+    EASY(-1, "쉬움"),
+    NORMAL(0, "보통"),
+    HARD(1, "어려움");
+
+    private final int value;
+    private final String label;
+
+    @JsonValue
+    public String getLabel() {
+        return label;
+    }
+
+    public Integer getValue() {
+        return value;
+    }
+
+    @JsonCreator
+    public static PerceivedDifficulty fromString(final String label) {
+        for (PerceivedDifficulty difficulty : values()) {
+            if (difficulty.label.equals(label)) {
+                return difficulty;
+            }
+        }
+        throw new IllegalArgumentException("Unknown difficulty: " + label);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
@@ -31,4 +31,13 @@ public enum PerceivedDifficulty {
         }
         throw new PerceivedDifficultyNotFoundException(label);
     }
+
+    public static PerceivedDifficulty fromValue(int value) {
+        for (PerceivedDifficulty difficulty : values()) {
+            if (difficulty.value == value) {
+                return difficulty;
+            }
+        }
+        throw new IllegalArgumentException("Unknown value: " + value);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
@@ -40,4 +40,8 @@ public enum PerceivedDifficulty {
         }
         throw new IllegalArgumentException("Unknown value: " + value);
     }
+
+    public int calculateDifferenceFrom(PerceivedDifficulty other) {
+        return this.value - other.value;
+    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficulty.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.domain;
 
+import com.first.flash.climbing.solution.exception.exceptions.PerceivedDifficultyNotFoundException;
 import lombok.AllArgsConstructor;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,6 +29,6 @@ public enum PerceivedDifficulty {
                 return difficulty;
             }
         }
-        throw new IllegalArgumentException("Unknown difficulty: " + label);
+        throw new PerceivedDifficultyNotFoundException(label);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficultyConverter.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficultyConverter.java
@@ -1,0 +1,18 @@
+package com.first.flash.climbing.solution.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class PerceivedDifficultyConverter implements AttributeConverter<PerceivedDifficulty, Integer> {
+
+    @Override
+    public Integer convertToDatabaseColumn(PerceivedDifficulty attribute) {
+        return attribute != null ? attribute.getValue() : null;
+    }
+
+    @Override
+    public PerceivedDifficulty convertToEntityAttribute(Integer dbData) {
+        return dbData != null ? PerceivedDifficulty.fromValue(dbData) : null;
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficultySetEvent.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/PerceivedDifficultySetEvent.java
@@ -1,0 +1,18 @@
+package com.first.flash.climbing.solution.domain;
+
+import com.first.flash.global.event.Event;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PerceivedDifficultySetEvent extends Event {
+
+    private UUID problemId;
+    private Integer perceivedDifficulty;
+
+    public static PerceivedDifficultySetEvent of(final UUID problemId, final Integer perceivedDifficulty) {
+        return new PerceivedDifficultySetEvent(problemId, perceivedDifficulty);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -34,7 +34,7 @@ public class Solution extends BaseEntity {
 
     protected Solution(final String uploader, final String review, final String instagramId,
         final String videoUrl, final UUID problemId, final UUID uploaderId,
-        final String profileImageUrl, final Integer perceivedDifficulty) {
+        final String profileImageUrl, final PerceivedDifficulty perceivedDifficulty) {
 
         this.solutionDetail = SolutionDetail.of(review, videoUrl, perceivedDifficulty);
         this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId, profileImageUrl);
@@ -44,7 +44,7 @@ public class Solution extends BaseEntity {
 
     public static Solution of(final String uploader, final String review, final String instagramId,
         final String videoUrl, final UUID problemId, final UUID uploaderId,
-        final String profileImageUrl, final Integer perceivedDifficulty) {
+        final String profileImageUrl, final PerceivedDifficulty perceivedDifficulty) {
 
         return new Solution(uploader, review, instagramId, videoUrl, problemId, uploaderId,
             profileImageUrl, perceivedDifficulty);
@@ -57,7 +57,7 @@ public class Solution extends BaseEntity {
         this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId, profileImageUrl);
     }
 
-    public void updateContentInfo(final String review, final String videoUrl, final Integer perceivedDifficulty) {
+    public void updateContentInfo(final String review, final String videoUrl, final PerceivedDifficulty perceivedDifficulty) {
         this.solutionDetail = SolutionDetail.of(review, videoUrl, perceivedDifficulty);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -34,9 +34,9 @@ public class Solution extends BaseEntity {
 
     protected Solution(final String uploader, final String review, final String instagramId,
         final String videoUrl, final UUID problemId, final UUID uploaderId,
-        final String profileImageUrl) {
+        final String profileImageUrl, final Integer perceivedDifficulty) {
 
-        this.solutionDetail = SolutionDetail.of(review, videoUrl);
+        this.solutionDetail = SolutionDetail.of(review, videoUrl, perceivedDifficulty);
         this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId, profileImageUrl);
         this.optionalWeight = DEFAULT_OPTIONAL_WEIGHT;
         this.problemId = problemId;
@@ -44,10 +44,10 @@ public class Solution extends BaseEntity {
 
     public static Solution of(final String uploader, final String review, final String instagramId,
         final String videoUrl, final UUID problemId, final UUID uploaderId,
-        final String profileImageUrl) {
+        final String profileImageUrl, final Integer perceivedDifficulty) {
 
         return new Solution(uploader, review, instagramId, videoUrl, problemId, uploaderId,
-            profileImageUrl);
+            profileImageUrl, perceivedDifficulty);
     }
 
     public void updateUploaderInfo(final String uploader, final String instagramId,
@@ -57,7 +57,7 @@ public class Solution extends BaseEntity {
         this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId, profileImageUrl);
     }
 
-    public void updateContentInfo(final String review, final String videoUrl) {
-        this.solutionDetail = SolutionDetail.of(review, videoUrl);
+    public void updateContentInfo(final String review, final String videoUrl, final Integer perceivedDifficulty) {
+        this.solutionDetail = SolutionDetail.of(review, videoUrl, perceivedDifficulty);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionDeletedEvent.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionDeletedEvent.java
@@ -10,9 +10,10 @@ import lombok.Getter;
 public class SolutionDeletedEvent extends Event {
 
     private UUID problemId;
+    private Integer perceivedDifficulty;
 
-    public static SolutionDeletedEvent of(final UUID problemId) {
-        return new SolutionDeletedEvent(problemId);
+    public static SolutionDeletedEvent of(final UUID problemId, final Integer perceivedDifficulty) {
+        return new SolutionDeletedEvent(problemId, perceivedDifficulty);
     }
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
@@ -1,10 +1,13 @@
 package com.first.flash.climbing.solution.domain.dto;
 
+import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
+import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 
 public record SolutionCreateRequestDto(
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
-    @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review) {
+    @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review,
+    @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
@@ -3,11 +3,13 @@ package com.first.flash.climbing.solution.domain.dto;
 import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 public record SolutionCreateRequestDto(
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
     @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review,
+    @NotNull(message = "체감 난이도는 필수입니다.")
     @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
@@ -1,5 +1,8 @@
 package com.first.flash.climbing.solution.domain.vo;
 
+import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
+import com.first.flash.climbing.solution.domain.PerceivedDifficultyConverter;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -15,15 +18,16 @@ public class SolutionDetail {
 
     private String review;
     private String videoUrl;
-    private Integer perceivedDifficulty;
+    @Convert(converter = PerceivedDifficultyConverter.class)
+    private PerceivedDifficulty perceivedDifficulty;
 
-    protected SolutionDetail(final String review, final String videoUrl, final Integer perceivedDifficulty) {
+    protected SolutionDetail(final String review, final String videoUrl, final PerceivedDifficulty perceivedDifficulty) {
         this.review = review;
         this.videoUrl = videoUrl;
         this.perceivedDifficulty = perceivedDifficulty;
     }
 
-    public static SolutionDetail of(final String review, final String videoUrl, final Integer perceivedDifficulty) {
+    public static SolutionDetail of(final String review, final String videoUrl, final PerceivedDifficulty perceivedDifficulty) {
         return new SolutionDetail(review, videoUrl, perceivedDifficulty);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
@@ -15,13 +15,15 @@ public class SolutionDetail {
 
     private String review;
     private String videoUrl;
+    private Integer perceivedDifficulty;
 
-    protected SolutionDetail(final String review, final String videoUrl) {
+    protected SolutionDetail(final String review, final String videoUrl, final Integer perceivedDifficulty) {
         this.review = review;
         this.videoUrl = videoUrl;
+        this.perceivedDifficulty = perceivedDifficulty;
     }
 
-    public static SolutionDetail of(final String review, final String videoUrl) {
-        return new SolutionDetail(review, videoUrl);
+    public static SolutionDetail of(final String review, final String videoUrl, final Integer perceivedDifficulty) {
+        return new SolutionDetail(review, videoUrl, perceivedDifficulty);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.solution.exception;
 
+import com.first.flash.climbing.solution.exception.exceptions.PerceivedDifficultyNotFoundException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeniedException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
 import com.first.flash.global.dto.ErrorResponseDto;
@@ -24,6 +25,14 @@ public class SolutionExceptionHandler {
         final SolutionAccessDeniedException exception) {
         ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                             .body(errorResponse);
+    }
+
+    @ExceptionHandler(PerceivedDifficultyNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handlePerceivedDifficultyNotFoundException(
+        final PerceivedDifficultyNotFoundException exception) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
                              .body(errorResponse);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/SolutionExceptionHandler.java
@@ -38,6 +38,12 @@ public class SolutionExceptionHandler {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 
+    @ExceptionHandler(PerceivedDifficultyNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handlePerceivedDifficultyNotFoundException(
+        final PerceivedDifficultyNotFoundException exception) {
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
+    }
+
     private ResponseEntity<ErrorResponseDto> getResponseWithStatus(final HttpStatus httpStatus,
         final RuntimeException exception) {
         ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
@@ -45,11 +51,4 @@ public class SolutionExceptionHandler {
                              .body(errorResponse);
     }
 
-    @ExceptionHandler(PerceivedDifficultyNotFoundException.class)
-    public ResponseEntity<ErrorResponseDto> handlePerceivedDifficultyNotFoundException(
-        final PerceivedDifficultyNotFoundException exception) {
-        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
-                             .body(errorResponse);
-    }
 }

--- a/src/main/java/com/first/flash/climbing/solution/exception/exceptions/PerceivedDifficultyNotFoundException.java
+++ b/src/main/java/com/first/flash/climbing/solution/exception/exceptions/PerceivedDifficultyNotFoundException.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.solution.exception.exceptions;
+
+public class PerceivedDifficultyNotFoundException extends RuntimeException {
+
+    public PerceivedDifficultyNotFoundException(final String label) {
+        super(String.format("해당하는 체감 난이도가 없습니다: %s", label));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -64,7 +64,8 @@ public class SolutionQueryDslRepository {
     public DetailSolutionDto findDetailSolutionById(final Long solutionId) {
         return jpaQueryFactory.select(Projections.constructor(DetailSolutionDto.class,
                                   solution.id, solution.solutionDetail.videoUrl, queryProblem.gymName,
-                                  queryProblem.sectorName, solution.solutionDetail.review, queryProblem.difficultyName,
+                                  queryProblem.sectorName, solution.solutionDetail.review,
+                                  queryProblem.difficultyName, solution.solutionDetail.perceivedDifficulty,
                                   queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
                               ))
                               .from(solution)

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -77,7 +77,7 @@ public class SolutionQueryDslRepository {
         return jpaQueryFactory.select(Projections.constructor(DetailSolutionDto.class,
                                   solution.id, solution.solutionDetail.videoUrl, queryProblem.gymName,
                                   queryProblem.sectorName, solution.solutionDetail.review,
-                                  queryProblem.difficultyName, solution.solutionDetail.perceivedDifficulty,
+                                  queryProblem.difficultyName, solutionComment.count(), solution.solutionDetail.perceivedDifficulty,
                                   queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
                               ))
                               .from(solution)

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
@@ -5,6 +5,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record DetailSolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
-                                String review, String difficultyName, PerceivedDifficulty perceivedDifficulty, LocalDate removalDate,
-                                LocalDate settingDate, LocalDateTime uploadedAt) {
+                                String review, String difficultyName, Long commentsCount, PerceivedDifficulty perceivedDifficulty,
+                                LocalDate removalDate, LocalDate settingDate, LocalDateTime uploadedAt) {
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
@@ -1,10 +1,10 @@
 package com.first.flash.climbing.solution.infrastructure.dto;
 
+import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record DetailSolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
-                                String review, String difficultyName, LocalDate removalDate,
+                                String review, String difficultyName, PerceivedDifficulty perceivedDifficulty, LocalDate removalDate,
                                 LocalDate settingDate, LocalDateTime uploadedAt) {
-
 }

--- a/src/main/java/com/first/flash/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/first/flash/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.first.flash.global.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -27,5 +28,12 @@ public class GlobalExceptionHandler {
         log.error(exception.getMessage());
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
                              .body(exception.getMessage());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<String> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
+            .body("요청 본문이 누락되었습니다.");
     }
 }


### PR DESCRIPTION
# 요약

- 업로드 시 체감 난이도 투표 기능
- 문제 조회 시 꿀 문제 표시 기능

# 내용

## 1. 체감 난이도 투표를 위한 컬럼 추가

### Solution

```java
public class SolutionDetail {

    ...

    @Convert(converter = PerceivedDifficultyConverter.class)
    private PerceivedDifficulty perceivedDifficulty;

    ...
 
```

- Solution, QueryProblem 엔티티에 `perceived difficulty`(체감 난이도) 컬럼을 추가했습니다.

### PerceivedDifficulty Enum

```java
public enum PerceivedDifficulty {
    EASY(-1, "쉬움"),
    NORMAL(0, "보통"),
    HARD(1, "어려움");

    private final Integer value;
    private final String label;

    @JsonValue
    public String getLabel() {
        return label;
    }

    @JsonCreator
    public static PerceivedDifficulty fromString(final String label) {
        for (PerceivedDifficulty difficulty : values()) {
            if (difficulty.label.equals(label)) {
                return difficulty;
            }
        }
        throw new PerceivedDifficultyNotFoundException(label);
    }

    // ...
```

- `PerceivedDifficulty` Enum을 추가했습니다.
  - JsonCreator 어노테이션을 이용하여 Json 문자열에서 Enum으로 변환했습니다.
  - ex) 쉬움 -> ` PerceivedDifficulty.EASY`
- 컨버터 클래스인 `PerceivedDifficultyConverter`를 사용하여 Enum을 Integer로 변환했습니다.
  - ex) `PerceivedDifficulty.EASY` -> -1

## 2. 체감 난이도 투표 추가

### 업로드 시 체감 난이도 투표 추가

- 체감 난이도 투표가 적용된 API는 다음과 같습니다.
  - 일반 업로드: POST `/problem/{problemId}/solutions`
  - 어드민 업로드: POST `/admin/problems/{problemId}/solutions`
  - 해설 수정: PATCH `/solutions/{solutionId}`

- 해설 업로드 필드에 `perceivedDifficulty` 추가
```json
{
  "videoUrl": "string",
  "review": "string",
  "perceivedDifficulty": "쉬움"
}
```

- 어드민 업로드 필드에도 `perceivedDifficulty`가 추가 되었지만, 업로드 서버에서 항상 "보통"으로 업로드합니다.

## 3. 체감 난이도 합계를 Query Problem에 저장

- 해설 업로드, 해설 수정, 해설 삭제 시 변경된 체감 난이도 합계를 Query Problem의 `perceived difficulty` 컬럼에 반영합니다.
- 해설 업로드: -1, 0, 1을 더함
  - `PerceivedDifficultySetEvent` 이벤트를 사용합니다.
- 해설 수정
  - 같은 난이도로 수정 시 중복 반영을 막기 위한 로직으로, `변경된 체감 난이도 - 이전 체감 난이도`를 더합니다.
  - `PerceivedDifficultySetEvent` 이벤트를 사용합니다.
  - ex) 쉬움 -> 어려움: -1 -> 1 => 1 - (-1) = 2 를 더합니다.
- 해설 삭제
  - -1, 0, 1을 뺍니다.
  - `SolutionDeletedEvent` 이벤트를 사용합니다.

### Query Problem

```java
    public void addPerceivedDifficulty(final Integer value) {
        perceivedDifficulty += value;
    }

    public void subtractPerceivedDifficulty(final Integer value) {
        perceivedDifficulty -= value;
    }
```

- Entity에 구현된 두 메서드를 사용하여 체감 난이도 값을 조정합니다.

## 4. problem 목록에 꿀 여부 만환

- 꿀 여부가 반환되는 API는 다음과 같습니다.
  - 문제 상세 조회: GET `/problems/{problemId}`
  - 문제 여러 건 조회: GET `/gyms/{gymId}/problems`

### isHoney 확인 로직

- QueryProblem 엔티티 내에 메서드를 통해 확인합니다.
- 체감 난이도 합계가 음수인 경우 꿀 문제로 판정합니다.
```java
    public Boolean isHoney() {
        return perceivedDifficulty < 0;
    }
```

### 필터링 구현

```java
    @GetMapping("/gyms/{gymId}/problems")
    public ResponseEntity<ProblemsResponseDto> findAllProblems(
        @PathVariable final Long gymId,
        @RequestParam(name = "cursor", required = false) final String cursor,
        @RequestParam(defaultValue = DEFAULT_SORT_BY, required = false) final String sortBy,
        @RequestParam(defaultValue = DEFAULT_SIZE, required = false) final int size,
        @RequestParam(required = false) final List<String> difficulty,
        @RequestParam(required = false) final List<String> sector,
        @RequestParam(name = "has-solution", required = false) final Boolean hasSolution,
        @RequestParam(name = "is-honey", required = false) final Boolean isHoney) {
        return ResponseEntity.ok(
            problemReadService.findAll(gymId, cursor, sortBy, size, difficulty, sector,
                hasSolution, isHoney));
    }
```

- url에 주어진 쿼리 파라미터 `is-honey` 값이 true인 경우, `perceived difficulty` 값이 음수인 문제만 반환합니다.

## 5. 문제 체감 난이도 가중치 조정 API

```java
    @PatchMapping("/admin/problems/{problemId}/perceivedDifficulty")
    public ResponseEntity<ProblemDetailResponseDto> changePerceivedDifficulty(
        @PathVariable final UUID problemId,
        @Valid @RequestBody final ProblemPerceivedDifficultyRequestDto requestDto) {
        return ResponseEntity.ok(problemsService.setPerceivedDifficulty(problemId, requestDto.perceivedDifficulty()));
    }
```

- 지정된 문제의 체감 난이도 값을 전달된 체감 난이도 값으로 변경합니다.
- 어드민 전용 API 입니다.