### PR TITLE
신고 콘텐츠 타입 추가

### DIFF
--- a/src/main/java/com/first/flash/account/member/application/ReportService.java
+++ b/src/main/java/com/first/flash/account/member/application/ReportService.java
@@ -25,8 +25,9 @@ public class ReportService {
         UUID reporterId = AuthUtil.getId();
         Member reporter = memberService.findById(reporterId);
         MemberReport memberReport = MemberReport.reportContent(request.reason(), reporter,
-            reportedContentId);
-        reportRepository.save(memberReport);
-        return MemberReportResponse.toDto(reportedContentId, request.reason());
+            reportedContentId, request.contentType());
+        MemberReport savedReport = reportRepository.save(memberReport);
+        return MemberReportResponse.toDto(savedReport.getReportedContentId(),
+            savedReport.getContentType(), savedReport.getReason());
     }
 }

--- a/src/main/java/com/first/flash/account/member/application/dto/MemberReportRequest.java
+++ b/src/main/java/com/first/flash/account/member/application/dto/MemberReportRequest.java
@@ -1,7 +1,11 @@
 package com.first.flash.account.member.application.dto;
 
+import com.first.flash.account.member.domain.ContentType;
+import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
-public record MemberReportRequest(@NotEmpty(message = "신고 사유는 필수입니다.") String reason) {
+public record MemberReportRequest(@NotEmpty(message = "신고 사유는 필수입니다.") String reason,
+                                  @NotNull(message = "콘텐츠 타입은 필수입니다.") @ValidEnum(enumClass = ContentType.class) ContentType contentType) {
 
 }

--- a/src/main/java/com/first/flash/account/member/application/dto/MemberReportResponse.java
+++ b/src/main/java/com/first/flash/account/member/application/dto/MemberReportResponse.java
@@ -1,8 +1,11 @@
 package com.first.flash.account.member.application.dto;
 
-public record MemberReportResponse(Long reportedContentId, String reason) {
+import com.first.flash.account.member.domain.ContentType;
 
-    public static MemberReportResponse toDto(final Long reportedContentId, final String reason) {
-        return new MemberReportResponse(reportedContentId, reason);
+public record MemberReportResponse(Long reportedContentId, String contentType, String reason) {
+
+    public static MemberReportResponse toDto(final Long reportedContentId,
+        final ContentType contentType, final String reason) {
+        return new MemberReportResponse(reportedContentId, contentType.name(), reason);
     }
 }

--- a/src/main/java/com/first/flash/account/member/domain/ContentType.java
+++ b/src/main/java/com/first/flash/account/member/domain/ContentType.java
@@ -1,0 +1,8 @@
+package com.first.flash.account.member.domain;
+
+import lombok.ToString;
+
+@ToString
+public enum ContentType {
+    SOLUTION, COMMENT;
+}

--- a/src/main/java/com/first/flash/account/member/domain/MemberReport.java
+++ b/src/main/java/com/first/flash/account/member/domain/MemberReport.java
@@ -3,6 +3,8 @@ package com.first.flash.account.member.domain;
 import com.first.flash.global.domain.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -27,15 +29,19 @@ public class MemberReport extends BaseEntity {
     @JoinColumn(name = "reporterId")
     private Member reporter;
     private Long reportedContentId;
+    @Enumerated(EnumType.STRING)
+    private ContentType contentType;
 
-    private MemberReport(final String reason, final Member reporter, final Long reportedContentId) {
+    private MemberReport(final String reason, final Member reporter, final Long reportedContentId,
+        final ContentType contentType) {
         this.reason = reason;
         this.reporter = reporter;
         this.reportedContentId = reportedContentId;
+        this.contentType = contentType;
     }
 
     public static MemberReport reportContent(final String reason, final Member reporter,
-        final Long reportedContentId) {
-        return new MemberReport(reason, reporter, reportedContentId);
+        final Long reportedContentId, final ContentType contentType) {
+        return new MemberReport(reason, reporter, reportedContentId, contentType);
     }
 }


### PR DESCRIPTION
## 요약
- 콘텐츠 타입 enum 객체 생성
- 신고 엔티티와 시나리오에 콘텐츠 타입 추가 

## 내용
### 콘텐츠 타입 enum
```java
@ToString
public enum ContentType {
    SOLUTION, COMMENT;
}
```
현재 유저가 업로드 가능한 콘텐츠들인 Solution과 Comment로 콘텐츠 타입 enum을 만들었습니다.

### 신고 엔티티와 시나리오에 콘텐츠 타입 추가
```java
MemberReport memberReport = MemberReport.reportContent(request.reason(), reporter,
            reportedContentId, request.contentType());
        MemberReport savedReport = reportRepository.save(memberReport);
        return MemberReportResponse.toDto(savedReport.getReportedContentId(),
            savedReport.getContentType(), savedReport.getReason());
```
신고 시나리오에 콘텐츠 타입을 추가했습니다.
여기서 콘텐츠 타입에 따라 해당 콘텐츠가 존재하는지 여부 유효성 검사가 반드시 필요할지 궁금합니다..!