### PR TITLE
앱 버전 조회 API 구현

### DIFF
--- a/src/main/java/com/first/flash/global/config/SecurityConfig.java
+++ b/src/main/java/com/first/flash/global/config/SecurityConfig.java
@@ -32,7 +32,8 @@ public class SecurityConfig {
         "/auth/login",
         "/swagger-ui/*",
         "/v1/api-docs/**",
-        "/flash-climbing-answer-health/**"
+        "/flash-climbing-answer-health/**",
+        "/versions"
     };
     private static final String COMPLETE_REGISTRATION = "/members";
     private static final String MARKETING_CONSENT = "/members/marketing-consent";

--- a/src/main/java/com/first/flash/version/application/VersionService.java
+++ b/src/main/java/com/first/flash/version/application/VersionService.java
@@ -1,0 +1,21 @@
+package com.first.flash.version.application;
+
+import com.first.flash.version.domain.AppVersion;
+import com.first.flash.version.infrastructure.VersionJpaRepository;
+import com.first.flash.version.application.dto.VersionResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VersionService {
+
+    private final VersionJpaRepository versionJpaRepository;
+
+    public VersionResponseDto getLatestVersions() {
+        AppVersion version = versionJpaRepository.findAll().get(0);
+        return new VersionResponseDto(version.getAndroid(), version.getIos());
+    }
+}

--- a/src/main/java/com/first/flash/version/application/VersionService.java
+++ b/src/main/java/com/first/flash/version/application/VersionService.java
@@ -1,6 +1,6 @@
 package com.first.flash.version.application;
 
-import com.first.flash.version.domain.AppVersion;
+import java.util.NoSuchElementException;
 import com.first.flash.version.infrastructure.VersionJpaRepository;
 import com.first.flash.version.application.dto.VersionResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +15,8 @@ public class VersionService {
     private final VersionJpaRepository versionJpaRepository;
 
     public VersionResponseDto getLatestVersions() {
-        AppVersion version = versionJpaRepository.findAll().get(0);
-        return new VersionResponseDto(version.getAndroid(), version.getIos());
+        return versionJpaRepository.findTopByOrderByIdDesc()
+                                   .map(version -> new VersionResponseDto(version.getAndroid(), version.getIos()))
+                                   .orElseThrow(() -> new NoSuchElementException("No version information available"));
     }
 }

--- a/src/main/java/com/first/flash/version/application/dto/VersionResponseDto.java
+++ b/src/main/java/com/first/flash/version/application/dto/VersionResponseDto.java
@@ -1,0 +1,4 @@
+package com.first.flash.version.application.dto;
+
+public record VersionResponseDto(String android, String ios) {
+}

--- a/src/main/java/com/first/flash/version/domain/AppVersion.java
+++ b/src/main/java/com/first/flash/version/domain/AppVersion.java
@@ -1,0 +1,24 @@
+package com.first.flash.version.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class AppVersion {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String android;
+    private String ios;
+
+}

--- a/src/main/java/com/first/flash/version/infrastructure/VersionJpaRepository.java
+++ b/src/main/java/com/first/flash/version/infrastructure/VersionJpaRepository.java
@@ -1,0 +1,10 @@
+package com.first.flash.version.infrastructure;
+
+import com.first.flash.version.domain.AppVersion;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VersionJpaRepository extends JpaRepository<AppVersion, Long> {
+
+    List<AppVersion> findAll();
+}

--- a/src/main/java/com/first/flash/version/infrastructure/VersionJpaRepository.java
+++ b/src/main/java/com/first/flash/version/infrastructure/VersionJpaRepository.java
@@ -1,10 +1,10 @@
 package com.first.flash.version.infrastructure;
 
 import com.first.flash.version.domain.AppVersion;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
 
 public interface VersionJpaRepository extends JpaRepository<AppVersion, Long> {
 
-    List<AppVersion> findAll();
+    Optional<AppVersion> findTopByOrderByIdDesc();
 }

--- a/src/main/java/com/first/flash/version/ui/VersionController.java
+++ b/src/main/java/com/first/flash/version/ui/VersionController.java
@@ -1,0 +1,36 @@
+package com.first.flash.version.ui;
+
+import com.first.flash.climbing.solution.application.dto.SolutionsPageResponseDto;
+import com.first.flash.version.application.VersionService;
+import com.first.flash.version.application.dto.VersionResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "versions", description = "앱 버전 정보 API")
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class VersionController {
+
+    private final VersionService versionService;
+
+    @Operation(summary = "버전 정보 조회", description = "앱 최신 버전 정보 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 조회함",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = VersionResponseDto.class)))
+    })
+    @GetMapping("versions")
+    public ResponseEntity<VersionResponseDto> getLatestVersions() {
+        VersionResponseDto versionInfo = versionService.getLatestVersions();
+        return ResponseEntity.ok(versionInfo);
+    }
+}


### PR DESCRIPTION
# 요약

앱 버전 정보를 조회할 수 있는 API 구현

# 내용

### 패키지 구조

```text
src/main/java/com/first/flash/
├── CorsConfig.java
├── FlashApplication.java
├── account
├── climbing
├── global
└── version
  ├── application
  │   └── VersionService.java
  ├── domain
  │   └── AppVersion.java
  ├── infrastructure
  │   └── VersionJpaRepository.java
  └── ui
      └── VersionController.java
```

- 버전 정보 API는 기존 패키지와 별개의 내용이라고 판단하여 새로운 패키지에 구현하였습니다.

### Entity

```java
@Entity
@NoArgsConstructor
@AllArgsConstructor
@Getter
@ToString
public class AppVersion {
    @Id
    @GeneratedValue(strategy = GenerationType.IDENTITY)
    private Long id;
    private String android;
    private String ios;

}

```

- android 버전 정보와 ios 버전 정보를 각각 저장할 수 있도록 구현하였습니다.

### 버전 정보 조회

- `GET /versions`을 통해 버전 정보를 조회할 수 있습니다.
  - DB에 들어있는 버전 정보 중 가장 최신 ID의 정보를 가져옵니다.
- SecurityConfig를 수정하여 토큰 없이 해당 API를 호출할 수 있도록 하였습니다.
- 응답 예시
```json
{
  "android": "1.0.4",
  "ios": "1.2.1"
}
```