### PR TITLE
로그를 JSON으로 통합

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // json
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/first/flash/account/auth/application/CustomUserDetailsService.java
+++ b/src/main/java/com/first/flash/account/auth/application/CustomUserDetailsService.java
@@ -19,6 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(final String id) throws UsernameNotFoundException {
         Member foundMember = memberService.findById(UUID.fromString(id));
-        return new CustomUserDetails(foundMember.getId(), foundMember.getRole());
+        return new CustomUserDetails(foundMember.getId(), foundMember.getRole(),
+            foundMember.getNickName());
     }
 }

--- a/src/main/java/com/first/flash/account/auth/application/dto/CustomUserDetails.java
+++ b/src/main/java/com/first/flash/account/auth/application/dto/CustomUserDetails.java
@@ -8,11 +8,15 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
-public record CustomUserDetails(UUID id, Role role) implements UserDetails {
+public record CustomUserDetails(UUID id, Role role, String nickName) implements UserDetails {
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return Collections.singletonList(new SimpleGrantedAuthority(role.name()));
+    }
+
+    public String getNickName() {
+        return nickName;
     }
 
     @Override

--- a/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
+++ b/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
@@ -104,7 +104,7 @@ public class LoggingAspect {
         }
     }
 
-    @AfterReturning(pointcut = "execution(* com.first.flash..*ExceptionHandler.*(..))", returning = "exception")
+    @AfterReturning(pointcut = "com.first.flash.global.aspect.PointCuts.allExceptionHandler()", returning = "exception")
     public void logException(final Object exception) {
         Map<String, Object> logData = logContext.get();
         logData.put("type", "error");

--- a/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
+++ b/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
@@ -1,7 +1,10 @@
 package com.first.flash.global.aspect;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.first.flash.account.auth.application.dto.CustomUserDetails;
+import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -28,6 +31,12 @@ public class LoggingAspect {
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final ThreadLocal<Map<String, Object>> logContext = ThreadLocal.withInitial(
         HashMap::new);
+
+    @PostConstruct
+    public void setUp() {
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // ISO-8601 형식으로 출력
+    }
 
     @AfterReturning(pointcut = "execution(* com.first.flash.account.auth.application.CustomUserDetailsService.loadUserByUsername(..))", returning = "userDetails")
     public void logUserDetails(final CustomUserDetails userDetails) {

--- a/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
+++ b/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
@@ -32,7 +32,7 @@ public class LoggingAspect {
     @AfterReturning(pointcut = "execution(* com.first.flash.account.auth.application.CustomUserDetailsService.loadUserByUsername(..))", returning = "userDetails")
     public void logUserDetails(final CustomUserDetails userDetails) {
         Map<String, Object> logData = logContext.get();
-        logData.put("Requester", userDetails.getNickName());
+        logData.put("requester", userDetails.getNickName());
         logContext.set(logData);
     }
 
@@ -54,13 +54,13 @@ public class LoggingAspect {
             String className = joinPoint.getTarget().getClass().getSimpleName();
 
             Map<String, Object> logData = logContext.get();
-            logData.put(className + " Method", method.getName());
+            logData.put(className + " method", method.getName());
 
             Object[] args = joinPoint.getArgs();
             if (args.length > 0) {
-                logData.put("Method Parameters", args);
+                logData.put("method param", args);
             } else {
-                logData.put("Method Parameters", "No parameters");
+                logData.put("method params", "no params");
             }
             logContext.set(logData);
         }
@@ -70,7 +70,7 @@ public class LoggingAspect {
     public void logMethodReturn(final JoinPoint joinPoint, final Object result) {
         if (log.isDebugEnabled()) {
             Map<String, Object> logData = logContext.get();
-            logData.put("Method Return Value", result);
+            logData.put("method return value", result);
             logContext.set(logData);
         }
     }
@@ -78,16 +78,17 @@ public class LoggingAspect {
     @AfterReturning(pointcut = "com.first.flash.global.aspect.PointCuts.allController()", returning = "result")
     public void logResponse(final Object result) {
         Map<String, Object> logData = logContext.get();
+        logData.put("type", "log");
 
         if (result instanceof ResponseEntity<?> responseEntity) {
-            logData.put("Response Status", responseEntity.getStatusCode().value());
-            logData.put("Response Body", responseEntity.getBody());
+            logData.put("response status", responseEntity.getStatusCode().value());
+            logData.put("response body", responseEntity.getBody());
         } else {
-            logData.put("Response", result);
+            logData.put("response", result);
         }
 
         try {
-            log.info("Unified Log: {}", objectMapper.writeValueAsString(logData));
+            log.info(objectMapper.writeValueAsString(logData));
         } catch (Exception e) {
             log.error("Error converting log to JSON", e);
         } finally {
@@ -95,109 +96,20 @@ public class LoggingAspect {
         }
     }
 
-    // ExceptionHandler에서 예외 기록
     @AfterThrowing(pointcut = "execution(* com.first.flash..*ExceptionHandler.*(..))", throwing = "exception")
-    public void logException(RuntimeException exception) {
+    public void logException(final RuntimeException exception) {
         Map<String, Object> logData = logContext.get();
 
-        logData.put("Error Class", exception.getClass().getSimpleName());
-        logData.put("Error Message", exception.getMessage());
+        logData.put("type", "error");
+        logData.put("error class", exception.getClass().getSimpleName());
+        logData.put("error message", exception.getMessage());
 
         try {
-            log.error("Unified Log with Exception: {}", objectMapper.writeValueAsString(logData));
+            log.error(objectMapper.writeValueAsString(logData));
         } catch (Exception e) {
             log.error("Error converting log with exception to JSON", e);
         } finally {
             logContext.remove();
         }
     }
-
-//    @Before("com.first.flash.global.aspect.PointCuts.allController()")
-//    public void doBeforeController() {
-//        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
-//            .getRequest();
-//
-//        log.info("======= Controller Start =======");
-//        log.info("Request URI: {}", request.getRequestURI());
-//        log.info("HTTP Method: {}", request.getMethod());
-//
-//        Enumeration<String> headerNames = request.getHeaderNames();
-//        while (headerNames.hasMoreElements()) {
-//            String headerName = headerNames.nextElement();
-//            log.info("Header: {} = {}", headerName, request.getHeader(headerName));
-//        }
-//
-//        Enumeration<String> parameterNames = request.getParameterNames();
-//        while (parameterNames.hasMoreElements()) {
-//            String parameterName = parameterNames.nextElement();
-//            log.info("Parameter: {} = {}", parameterName, request.getParameter(parameterName));
-//        }
-//    }
-//
-//    @Before("com.first.flash.global.aspect.PointCuts.verifiedControllers()")
-//    public void doBeforeVerifiedController() {
-//        log.info("user id: {}", AuthUtil.getId());
-//    }
-//
-//    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allController()", returning = "result")
-//    public void afterReturnController(final Object result) {
-//        if (result instanceof ResponseEntity<?> responseEntity) {
-//            int statusCode = responseEntity.getStatusCode().value();
-//            Object responseBody = responseEntity.getBody();
-//
-//            log.info("Response Status Code: {}", statusCode);
-//            if (!Objects.isNull(responseBody)) {
-//                log.info("Response Body: {}", responseBody);
-//            } else {
-//                log.info("no Response Body");
-//            }
-//        } else {
-//            if (!Objects.isNull(result)) {
-//                log.info("Response: {}", result);
-//            } else {
-//                log.info("no Response");
-//            }
-//        }
-//        log.info("======= Controller End =======");
-//    }
-//
-//    @Before("com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()")
-//    public void doBefore(final JoinPoint joinPoint) {
-//        Method method = getMethod(joinPoint);
-//        String objectName = joinPoint.getTarget()
-//                                     .getClass()
-//                                     .getSimpleName();
-//        log.info("======= {} Start =======", objectName);
-//        log.info("method name = {}", method.getName());
-//        Object[] args = joinPoint.getArgs();
-//        if (Objects.isNull(args) || args.length == 0) {
-//            log.info("no parameter");
-//            return;
-//        }
-//        for (Object arg : args) {
-//            if (Objects.isNull(arg)) {
-//                continue;
-//            }
-//            log.info("parameter type = {}", arg.getClass().getSimpleName());
-//            log.info("parameter value = {}", arg);
-//        }
-//    }
-//
-//    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
-//    public void afterReturnLog(final JoinPoint joinPoint, final Object result) {
-//        if (Objects.isNull(result)) {
-//            return;
-//        }
-//        log.info("return type = {}", result.getClass().getSimpleName());
-//        log.info("return value = {}", result);
-//        String objectName = joinPoint.getTarget()
-//                                     .getClass()
-//                                     .getSimpleName();
-//        log.info("======= {} End =======", objectName);
-//    }
-//
-//    private Method getMethod(final JoinPoint joinPoint) {
-//        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-//        return signature.getMethod();
-//    }
 }

--- a/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
+++ b/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
@@ -1,14 +1,16 @@
 package com.first.flash.global.aspect;
 
-import com.first.flash.global.util.AuthUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.first.flash.account.auth.application.dto.CustomUserDetails;
 import jakarta.servlet.http.HttpServletRequest;
 import java.lang.reflect.Method;
-import java.util.Enumeration;
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.reflect.MethodSignature;
@@ -23,92 +25,179 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @RequiredArgsConstructor
 public class LoggingAspect {
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ThreadLocal<Map<String, Object>> logContext = ThreadLocal.withInitial(
+        HashMap::new);
+
+    @AfterReturning(pointcut = "execution(* com.first.flash.account.auth.application.CustomUserDetailsService.loadUserByUsername(..))", returning = "userDetails")
+    public void logUserDetails(final CustomUserDetails userDetails) {
+        Map<String, Object> logData = logContext.get();
+        logData.put("Requester", userDetails.getNickName());
+        logContext.set(logData);
+    }
+
     @Before("com.first.flash.global.aspect.PointCuts.allController()")
-    public void doBeforeController() {
-        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
-            .getRequest();
+    public void logRequestInfo(final JoinPoint joinPoint) {
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
 
-        log.info("======= Controller Start =======");
-        log.info("Request URI: {}", request.getRequestURI());
-        log.info("HTTP Method: {}", request.getMethod());
-
-        Enumeration<String> headerNames = request.getHeaderNames();
-        while (headerNames.hasMoreElements()) {
-            String headerName = headerNames.nextElement();
-            log.info("Header: {} = {}", headerName, request.getHeader(headerName));
-        }
-
-        Enumeration<String> parameterNames = request.getParameterNames();
-        while (parameterNames.hasMoreElements()) {
-            String parameterName = parameterNames.nextElement();
-            log.info("Parameter: {} = {}", parameterName, request.getParameter(parameterName));
-        }
-    }
-
-    @Before("com.first.flash.global.aspect.PointCuts.verifiedControllers()")
-    public void doBeforeVerifiedController() {
-        log.info("user id: {}", AuthUtil.getId());
-    }
-
-    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allController()", returning = "result")
-    public void afterReturnController(final Object result) {
-        if (result instanceof ResponseEntity<?> responseEntity) {
-            int statusCode = responseEntity.getStatusCode().value();
-            Object responseBody = responseEntity.getBody();
-
-            log.info("Response Status Code: {}", statusCode);
-            if (!Objects.isNull(responseBody)) {
-                log.info("Response Body: {}", responseBody);
-            } else {
-                log.info("no Response Body");
-            }
-        } else {
-            if (!Objects.isNull(result)) {
-                log.info("Response: {}", result);
-            } else {
-                log.info("no Response");
-            }
-        }
-        log.info("======= Controller End =======");
+        Map<String, Object> logData = logContext.get();
+        logData.put("request URI", request.getRequestURI());
+        logData.put("HTTP method", request.getMethod());
+        logContext.set(logData);
     }
 
     @Before("com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()")
-    public void doBefore(final JoinPoint joinPoint) {
-        Method method = getMethod(joinPoint);
-        String objectName = joinPoint.getTarget()
-                                     .getClass()
-                                     .getSimpleName();
-        log.info("======= {} Start =======", objectName);
-        log.info("method name = {}", method.getName());
-        Object[] args = joinPoint.getArgs();
-        if (Objects.isNull(args) || args.length == 0) {
-            log.info("no parameter");
-            return;
-        }
-        for (Object arg : args) {
-            if (Objects.isNull(arg)) {
-                continue;
+    public void logMethodDetails(final JoinPoint joinPoint) {
+        if (log.isDebugEnabled()) {
+            MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+            Method method = signature.getMethod();
+            String className = joinPoint.getTarget().getClass().getSimpleName();
+
+            Map<String, Object> logData = logContext.get();
+            logData.put(className + " Method", method.getName());
+
+            Object[] args = joinPoint.getArgs();
+            if (args.length > 0) {
+                logData.put("Method Parameters", args);
+            } else {
+                logData.put("Method Parameters", "No parameters");
             }
-            log.info("parameter type = {}", arg.getClass().getSimpleName());
-            log.info("parameter value = {}", arg);
+            logContext.set(logData);
         }
     }
 
-    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
-    public void afterReturnLog(final JoinPoint joinPoint, final Object result) {
-        if (Objects.isNull(result)) {
-            return;
+    @AfterReturning(pointcut = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
+    public void logMethodReturn(final JoinPoint joinPoint, final Object result) {
+        if (log.isDebugEnabled()) {
+            Map<String, Object> logData = logContext.get();
+            logData.put("Method Return Value", result);
+            logContext.set(logData);
         }
-        log.info("return type = {}", result.getClass().getSimpleName());
-        log.info("return value = {}", result);
-        String objectName = joinPoint.getTarget()
-                                     .getClass()
-                                     .getSimpleName();
-        log.info("======= {} End =======", objectName);
     }
 
-    private Method getMethod(final JoinPoint joinPoint) {
-        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-        return signature.getMethod();
+    @AfterReturning(pointcut = "com.first.flash.global.aspect.PointCuts.allController()", returning = "result")
+    public void logResponse(final Object result) {
+        Map<String, Object> logData = logContext.get();
+
+        if (result instanceof ResponseEntity<?> responseEntity) {
+            logData.put("Response Status", responseEntity.getStatusCode().value());
+            logData.put("Response Body", responseEntity.getBody());
+        } else {
+            logData.put("Response", result);
+        }
+
+        try {
+            log.info("Unified Log: {}", objectMapper.writeValueAsString(logData));
+        } catch (Exception e) {
+            log.error("Error converting log to JSON", e);
+        } finally {
+            logContext.remove();
+        }
     }
+
+    // ExceptionHandler에서 예외 기록
+    @AfterThrowing(pointcut = "execution(* com.first.flash..*ExceptionHandler.*(..))", throwing = "exception")
+    public void logException(RuntimeException exception) {
+        Map<String, Object> logData = logContext.get();
+
+        logData.put("Error Class", exception.getClass().getSimpleName());
+        logData.put("Error Message", exception.getMessage());
+
+        try {
+            log.error("Unified Log with Exception: {}", objectMapper.writeValueAsString(logData));
+        } catch (Exception e) {
+            log.error("Error converting log with exception to JSON", e);
+        } finally {
+            logContext.remove();
+        }
+    }
+
+//    @Before("com.first.flash.global.aspect.PointCuts.allController()")
+//    public void doBeforeController() {
+//        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes())
+//            .getRequest();
+//
+//        log.info("======= Controller Start =======");
+//        log.info("Request URI: {}", request.getRequestURI());
+//        log.info("HTTP Method: {}", request.getMethod());
+//
+//        Enumeration<String> headerNames = request.getHeaderNames();
+//        while (headerNames.hasMoreElements()) {
+//            String headerName = headerNames.nextElement();
+//            log.info("Header: {} = {}", headerName, request.getHeader(headerName));
+//        }
+//
+//        Enumeration<String> parameterNames = request.getParameterNames();
+//        while (parameterNames.hasMoreElements()) {
+//            String parameterName = parameterNames.nextElement();
+//            log.info("Parameter: {} = {}", parameterName, request.getParameter(parameterName));
+//        }
+//    }
+//
+//    @Before("com.first.flash.global.aspect.PointCuts.verifiedControllers()")
+//    public void doBeforeVerifiedController() {
+//        log.info("user id: {}", AuthUtil.getId());
+//    }
+//
+//    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allController()", returning = "result")
+//    public void afterReturnController(final Object result) {
+//        if (result instanceof ResponseEntity<?> responseEntity) {
+//            int statusCode = responseEntity.getStatusCode().value();
+//            Object responseBody = responseEntity.getBody();
+//
+//            log.info("Response Status Code: {}", statusCode);
+//            if (!Objects.isNull(responseBody)) {
+//                log.info("Response Body: {}", responseBody);
+//            } else {
+//                log.info("no Response Body");
+//            }
+//        } else {
+//            if (!Objects.isNull(result)) {
+//                log.info("Response: {}", result);
+//            } else {
+//                log.info("no Response");
+//            }
+//        }
+//        log.info("======= Controller End =======");
+//    }
+//
+//    @Before("com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()")
+//    public void doBefore(final JoinPoint joinPoint) {
+//        Method method = getMethod(joinPoint);
+//        String objectName = joinPoint.getTarget()
+//                                     .getClass()
+//                                     .getSimpleName();
+//        log.info("======= {} Start =======", objectName);
+//        log.info("method name = {}", method.getName());
+//        Object[] args = joinPoint.getArgs();
+//        if (Objects.isNull(args) || args.length == 0) {
+//            log.info("no parameter");
+//            return;
+//        }
+//        for (Object arg : args) {
+//            if (Objects.isNull(arg)) {
+//                continue;
+//            }
+//            log.info("parameter type = {}", arg.getClass().getSimpleName());
+//            log.info("parameter value = {}", arg);
+//        }
+//    }
+//
+//    @AfterReturning(value = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
+//    public void afterReturnLog(final JoinPoint joinPoint, final Object result) {
+//        if (Objects.isNull(result)) {
+//            return;
+//        }
+//        log.info("return type = {}", result.getClass().getSimpleName());
+//        log.info("return value = {}", result);
+//        String objectName = joinPoint.getTarget()
+//                                     .getClass()
+//                                     .getSimpleName();
+//        log.info("======= {} End =======", objectName);
+//    }
+//
+//    private Method getMethod(final JoinPoint joinPoint) {
+//        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+//        return signature.getMethod();
+//    }
 }

--- a/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
+++ b/src/main/java/com/first/flash/global/aspect/LoggingAspect.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.first.flash.account.auth.application.dto.CustomUserDetails;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -15,7 +14,6 @@ import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
-import org.aspectj.lang.reflect.MethodSignature;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -54,34 +52,34 @@ public class LoggingAspect {
         logContext.set(logData);
     }
 
-    @Before("com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()")
-    public void logMethodDetails(final JoinPoint joinPoint) {
-        if (log.isDebugEnabled()) {
-            MethodSignature signature = (MethodSignature) joinPoint.getSignature();
-            Method method = signature.getMethod();
-            String className = joinPoint.getTarget().getClass().getSimpleName();
-
-            Map<String, Object> logData = logContext.get();
-            logData.put(className + " method", method.getName());
-
-            Object[] args = joinPoint.getArgs();
-            if (args.length > 0) {
-                logData.put("method param", args);
-            } else {
-                logData.put("method params", "no params");
-            }
-            logContext.set(logData);
-        }
-    }
-
-    @AfterReturning(pointcut = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
-    public void logMethodReturn(final JoinPoint joinPoint, final Object result) {
-        if (log.isDebugEnabled()) {
-            Map<String, Object> logData = logContext.get();
-            logData.put("method return value", result);
-            logContext.set(logData);
-        }
-    }
+//    @Before("com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()")
+//    public void logMethodDetails(final JoinPoint joinPoint) {
+//        if (log.isDebugEnabled()) {
+//            String key = generateLogKey(joinPoint);
+//
+//            Map<String, Object> methodDetails = new HashMap<>();
+//            Object[] args = joinPoint.getArgs();
+//            if (args.length > 0) {
+//                methodDetails.put("params", args);
+//            } else {
+//                methodDetails.put("params", "no params");
+//            }
+//
+//            updateLogContext(key, methodDetails);
+//        }
+//    }
+//
+//    @AfterReturning(pointcut = "com.first.flash.global.aspect.PointCuts.allService() || com.first.flash.global.aspect.PointCuts.allRepository()", returning = "result")
+//    public void logMethodReturn(final JoinPoint joinPoint, final Object result) {
+//        if (log.isDebugEnabled()) {
+//            String key = generateLogKey(joinPoint);
+//
+//            Map<String, Object> methodDetails = new HashMap<>();
+//            methodDetails.put("returnValue", result);
+//
+//            updateLogContext(key, methodDetails);
+//        }
+//    }
 
     @AfterReturning(pointcut = "com.first.flash.global.aspect.PointCuts.allController()", returning = "result")
     public void logResponse(final Object result) {
@@ -124,4 +122,25 @@ public class LoggingAspect {
             logContext.remove();
         }
     }
+
+//    private String generateLogKey(final JoinPoint joinPoint) {
+//        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+//        String className = joinPoint.getTarget().getClass().getSimpleName();
+//        String methodName = signature.getMethod().getName();
+//        return className + "." + methodName;
+//    }
+//
+//    private void updateLogContext(final String key, final Map<String, Object> methodDetails) {
+//        Map<String, Object> logData = logContext.get();
+//
+//        if (logData.containsKey(key)) {
+//            Map<String, Object> existingDetails = (Map<String, Object>) logData.get(key);
+//            existingDetails.putAll(methodDetails);
+//            logData.put(key, existingDetails);
+//        } else {
+//            logData.put(key, methodDetails);
+//        }
+//
+//        logContext.set(logData);
+//    }
 }

--- a/src/main/java/com/first/flash/global/aspect/PointCuts.java
+++ b/src/main/java/com/first/flash/global/aspect/PointCuts.java
@@ -16,8 +16,11 @@ public class PointCuts {
     public void allRepository() {
     }
 
+    @Pointcut("execution(* com.first.flash..*ExceptionHandler.*(..))")
+    public void allExceptionHandler() {
+    }
+
     @Pointcut("execution(* com.first.flash.climbing..*Controller.*(..))")
     public void verifiedControllers() {
-
     }
 }


### PR DESCRIPTION
## 요약
- 기존 한 줄씩 출력되던 로그를 통합
- 요청 당 하나의 로그가 JSON으로 출력되도록 함

## 내용
### JSON 형식
일반 응답
```json
{
   "type":"log",
   "request URI": "요청 uri",
   "requester": "요청자 닉네임",
   "HTTP method": "요청 HTTP 메서드",
   "response status": "응답 상태 코드",
   "response body": "응답 바디"
}
```

에러
```json
{
   "type":"error",
   "request URI": "요청 uri",
   "requester": "요청자 닉네임",
   "HTTP method": "요청 HTTP 메서드",
   "error status": "에러 상태 코드",
   "error body":  "에러 바디"
}
```
위처럼 로그에 대한 형식을 정해 구현했습니다!