### PR TITLE
섹터 고정 정보 정규화

### DIFF
--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -8,6 +8,7 @@ import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
 import com.first.flash.climbing.gym.domian.vo.Difficulty;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
+import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -39,14 +40,14 @@ public class ClimbingGymService {
 
     public ClimbingGymDetailResponseDto findClimbingGymDetail(final Long id) {
         ClimbingGym climbingGym = findClimbingGymById(id);
-        List<String> sectorNames = findSectorNamesById(id);
+        List<SectorInfoResponseDto> sectorNames = findSectorNamesById(id);
         List<String> difficultyNames = getDifficultyNames(climbingGym);
         return new ClimbingGymDetailResponseDto(climbingGym.getGymName(),
             climbingGym.getMapImageUrl(), climbingGym.getCalendarImageUrl(),
             difficultyNames, sectorNames);
     }
 
-    private List<String> findSectorNamesById(final Long id) {
+    private List<SectorInfoResponseDto> findSectorNamesById(final Long id) {
         return climbingGymRepository.findGymSectorNamesById(id);
     }
 

--- a/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymDetailResponseDto.java
@@ -1,10 +1,11 @@
 package com.first.flash.climbing.gym.application.dto;
 
+import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
 import java.util.List;
 
 public record ClimbingGymDetailResponseDto(String gymName, String mapImageUrl,
                                            String calendarImageUrl,
                                            List<String> difficulties,
-                                           List<String> sectors) {
+                                           List<SectorInfoResponseDto> sectors) {
 
 }

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.gym.domian;
 
+import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
 import java.util.List;
 import java.util.Optional;
 
@@ -11,5 +12,5 @@ public interface ClimbingGymRepository {
 
     List<ClimbingGym> findAll();
 
-    List<String> findGymSectorNamesById(final Long id);
+    List<SectorInfoResponseDto> findGymSectorNamesById(final Long id);
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
@@ -2,6 +2,8 @@ package com.first.flash.climbing.gym.infrastructure;
 
 import static com.first.flash.climbing.sector.domain.QSector.sector;
 
+import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -13,8 +15,10 @@ public class ClimbingGymQueryDslRepository {
 
     private final JPAQueryFactory jpaQueryFactory;
 
-    public List<String> findSortedSectorNamesByGymId(final Long gymId) {
-        return jpaQueryFactory.select(sector.sectorName.name)
+    public List<SectorInfoResponseDto> findSortedSectorNamesByGymId(final Long gymId) {
+        return jpaQueryFactory.select(
+                                  Projections.constructor(SectorInfoResponseDto.class, sector.sectorName.name,
+                                      sector.selectedImageUrl))
                               .from(sector)
                               .where(sector.gymId.eq(gymId), sector.removalInfo.isExpired.isFalse())
                               .distinct()

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.gym.infrastructure;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
+import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class ClimbingGymRepositoryImpl implements ClimbingGymRepository {
     }
 
     @Override
-    public List<String> findGymSectorNamesById(final Long id) {
+    public List<SectorInfoResponseDto> findGymSectorNamesById(final Long id) {
         return climbingGymQueryDslRepository.findSortedSectorNamesByGymId(id);
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/dto/SectorInfoResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/dto/SectorInfoResponseDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.climbing.gym.infrastructure.dto;
+
+public record SectorInfoResponseDto(String name, String selectedImageUrl) {
+
+}

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.problem.application;
 
 import com.first.flash.climbing.problem.domain.ProblemIdConfirmRequestedEvent;
+import com.first.flash.climbing.sector.application.SectorFixedInfoUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorExpiredEvent;
 import com.first.flash.climbing.sector.domain.SectorInfoUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
@@ -48,6 +49,12 @@ public class ProblemEventHandler {
     public void updateQueryProblemInfo(final SectorInfoUpdatedEvent event) {
         problemsService.updateQueryProblemInfo(event.getId(), event.getSectorName(),
             event.getSettingDate());
+    }
+
+    @EventListener
+    @Transactional
+    public void updateQueryProblemFixedInfo(final SectorFixedInfoUpdatedEvent event) {
+        problemsService.updateQueryProblemFixedInfo(event.getSectorIds(), event.getSectorName());
     }
 
     @EventListener

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -23,7 +23,8 @@ public class ProblemEventHandler {
     @EventListener
     @Transactional
     public void changeRemovalDate(final SectorRemovalDateUpdatedEvent event) {
-        problemsService.changeRemovalDate(event.getSectorId(), event.getRemovalDate());
+        problemsService.changeRemovalDate(event.getSectorId(), event.getRemovalDate(),
+            event.isExpired());
     }
 
     @EventListener
@@ -41,7 +42,8 @@ public class ProblemEventHandler {
     @EventListener
     @Transactional
     public void updateProblemDeletedSolutionInfo(final SolutionDeletedEvent event) {
-        problemsService.updateProblemDeletedSolutionInfo(event.getProblemId(), event.getPerceivedDifficulty());
+        problemsService.updateProblemDeletedSolutionInfo(event.getProblemId(),
+            event.getPerceivedDifficulty());
     }
 
     @EventListener
@@ -66,6 +68,7 @@ public class ProblemEventHandler {
     @EventListener
     @Transactional
     public void updatePerceivedDifficulty(final PerceivedDifficultySetEvent event) {
-        problemsService.addPerceivedDifficulty(event.getProblemId(), event.getPerceivedDifficulty());
+        problemsService.addPerceivedDifficulty(event.getProblemId(),
+            event.getPerceivedDifficulty());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -1,7 +1,7 @@
 package com.first.flash.climbing.problem.application;
 
 import com.first.flash.climbing.problem.domain.ProblemIdConfirmRequestedEvent;
-import com.first.flash.climbing.sector.application.SectorFixedInfoUpdatedEvent;
+import com.first.flash.climbing.sector.domain.SectorFixedInfoUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorExpiredEvent;
 import com.first.flash.climbing.sector.domain.SectorInfoUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -48,7 +48,7 @@ public class ProblemEventHandler {
     @Transactional
     public void updateQueryProblemInfo(final SectorInfoUpdatedEvent event) {
         problemsService.updateQueryProblemInfo(event.getId(), event.getSectorName(),
-            event.getSettingDate());
+            event.getSettingDate(), event.isExpired());
     }
 
     @EventListener

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -21,8 +21,8 @@ public class ProblemsService {
     private final ProblemReadService problemReadService;
 
     @Transactional
-    public void changeRemovalDate(final Long sectorId, final LocalDate removalDate) {
-        queryProblemRepository.updateRemovalDateBySectorId(sectorId, removalDate);
+    public void changeRemovalDate(final Long sectorId, final LocalDate removalDate, final boolean isExpired) {
+        queryProblemRepository.updateRemovalDateBySectorId(sectorId, removalDate, isExpired);
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -62,4 +62,8 @@ public class ProblemsService {
         queryProblem.setPerceivedDifficulty(perceivedDifficulty);
         return ProblemDetailResponseDto.of(queryProblem);
     }
+
+    public void updateQueryProblemFixedInfo(final List<Long> sectorIds, final String sectorName) {
+        queryProblemRepository.updateSectorNameBySectorIds(sectorIds, sectorName);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -38,7 +38,8 @@ public class ProblemsService {
     }
 
     @Transactional
-    public void updateProblemDeletedSolutionInfo(final UUID problemId, final Integer perceivedDifficulty) {
+    public void updateProblemDeletedSolutionInfo(final UUID problemId,
+        final Integer perceivedDifficulty) {
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
         queryProblem.decrementSolutionCount();
         queryProblem.subtractPerceivedDifficulty(perceivedDifficulty);
@@ -46,8 +47,8 @@ public class ProblemsService {
 
     @Transactional
     public void updateQueryProblemInfo(final Long sectorId, final String sectorName,
-        final LocalDate settingDate) {
-        queryProblemRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate);
+        final LocalDate settingDate, final boolean isExpired) {
+        queryProblemRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate, isExpired);
     }
 
     @Transactional
@@ -57,7 +58,8 @@ public class ProblemsService {
     }
 
     @Transactional
-    public ProblemDetailResponseDto setPerceivedDifficulty(final UUID problemId, final Integer perceivedDifficulty) {
+    public ProblemDetailResponseDto setPerceivedDifficulty(final UUID problemId,
+        final Integer perceivedDifficulty) {
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
         queryProblem.setPerceivedDifficulty(perceivedDifficulty);
         return ProblemDetailResponseDto.of(queryProblem);

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -17,7 +17,7 @@ public interface QueryProblemRepository {
         final Long gymId, final List<String> difficulty, final List<String> sector,
         final Boolean hasSolution, final Boolean isHoney);
 
-    void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate);
+    void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate, final boolean isExpired);
 
     void expireProblemsBySectorIds(final List<Long> expiredSectorsIds);
 

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -22,7 +22,7 @@ public interface QueryProblemRepository {
     void expireProblemsBySectorIds(final List<Long> expiredSectorsIds);
 
     void updateQueryProblemInfo(final Long sectorId, final String sectorName,
-        final LocalDate settingDate);
+        final LocalDate settingDate, final boolean isExpired);
 
     void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -23,4 +23,6 @@ public interface QueryProblemRepository {
 
     void updateQueryProblemInfo(final Long sectorId, final String sectorName,
         final LocalDate settingDate);
+
+    void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -53,10 +53,11 @@ public class QueryProblemQueryDslRepository {
     }
 
     public void updateQueryProblemInfo(final Long sectorId, final String sectorName,
-        final LocalDate settingDate) {
+        final LocalDate settingDate, final boolean isExpired) {
         queryFactory.update(queryProblem)
                     .set(queryProblem.sectorName, sectorName)
                     .set(queryProblem.settingDate, settingDate)
+                    .set(queryProblem.isExpired, isExpired)
                     .where(queryProblem.sectorId.eq(sectorId))
                     .execute();
     }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -37,9 +37,11 @@ public class QueryProblemQueryDslRepository {
             .fetch();
     }
 
-    public void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate) {
+    public void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate,
+        final boolean isExpired) {
         queryFactory.update(queryProblem)
                     .set(queryProblem.removalDate, removalDate)
+                    .set(queryProblem.isExpired, isExpired)
                     .set(queryProblem.isFakeRemovalDate, false)
                     .where(queryProblem.sectorId.eq(sectorId))
                     .execute();

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemQueryDslRepository.java
@@ -23,12 +23,14 @@ public class QueryProblemQueryDslRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    public List<QueryProblem> findAll(final ProblemCursor prevProblemCursor, final ProblemSortBy problemSortBy, final int size,
+    public List<QueryProblem> findAll(final ProblemCursor prevProblemCursor,
+        final ProblemSortBy problemSortBy, final int size,
         final Long gymId, final List<String> difficulty, final List<String> sector,
         final Boolean hasSolution, final Boolean isHoney) {
         return queryFactory
             .selectFrom(queryProblem)
-            .where(notExpired(), cursorCondition(prevProblemCursor), inGym(gymId), inSectors(sector),
+            .where(notExpired(), cursorCondition(prevProblemCursor), inGym(gymId),
+                inSectors(sector),
                 inDifficulties(difficulty), hasSolution(hasSolution), isHoneyCondition(isHoney))
             .orderBy(sortItem(problemSortBy), queryProblem.id.desc())
             .limit(size)
@@ -132,5 +134,12 @@ public class QueryProblemQueryDslRepository {
             return null;
         }
         return queryProblem.hasSolution.eq(hasSolution);
+    }
+
+    public void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName) {
+        queryFactory.update(queryProblem)
+                    .set(queryProblem.sectorName, sectorName)
+                    .where(queryProblem.sectorId.in(sectorIds))
+                    .execute();
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -29,7 +29,8 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
     }
 
     @Override
-    public List<QueryProblem> findAll(final ProblemCursor prevProblemCursor, final ProblemSortBy problemSortBy, final int size,
+    public List<QueryProblem> findAll(final ProblemCursor prevProblemCursor,
+        final ProblemSortBy problemSortBy, final int size,
         final Long gymId, final List<String> difficulty, final List<String> sector,
         final Boolean hasSolution, final Boolean isHoney) {
         return queryProblemQueryDslRepository.findAll(prevProblemCursor, problemSortBy, size,
@@ -48,8 +49,9 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
 
     @Override
     public void updateQueryProblemInfo(final Long sectorId, final String sectorName,
-        final LocalDate settingDate) {
-        queryProblemQueryDslRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate);
+        final LocalDate settingDate, final boolean isExpired) {
+        queryProblemQueryDslRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate,
+            isExpired);
     }
 
     @Override

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -38,8 +38,8 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
     }
 
     @Override
-    public void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate) {
-        queryProblemQueryDslRepository.updateRemovalDateBySectorId(sectorId, removalDate);
+    public void updateRemovalDateBySectorId(final Long sectorId, final LocalDate removalDate, final boolean isExpired) {
+        queryProblemQueryDslRepository.updateRemovalDateBySectorId(sectorId, removalDate, isExpired);
     }
 
     @Override

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -51,4 +51,9 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
         final LocalDate settingDate) {
         queryProblemQueryDslRepository.updateQueryProblemInfo(sectorId, sectorName, settingDate);
     }
+
+    @Override
+    public void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName) {
+        queryProblemQueryDslRepository.updateSectorNameBySectorIds(sectorIds, sectorName);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorFixedInfoUpdatedEvent.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorFixedInfoUpdatedEvent.java
@@ -1,0 +1,19 @@
+package com.first.flash.climbing.sector.application;
+
+import com.first.flash.climbing.sector.domain.SectorInfo;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SectorFixedInfoUpdatedEvent {
+
+    private List<Long> sectorIds;
+    private String sectorName;
+
+    public static SectorFixedInfoUpdatedEvent of(final List<Long> sectorIds,
+        final SectorInfo sectorInfo) {
+        return new SectorFixedInfoUpdatedEvent(sectorIds, sectorInfo.getSectorName().getName());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.sector.application;
 
 import com.first.flash.climbing.gym.domian.ClimbingGymIdConfirmRequestedEvent;
 import com.first.flash.climbing.sector.application.dto.SectorInfosDetailResponseDto;
+import com.first.flash.climbing.sector.domain.SectorFixedInfoUpdatedEvent;
 import com.first.flash.climbing.sector.infrastructure.dto.UpdateSectorsDto;
 import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorDetailResponseDto;

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
@@ -58,7 +58,7 @@ public class SectorService {
         Sector sector = findById(sectorId);
         LocalDate removalDate = sectorUpdateRemovalDateRequestDto.removalDate();
         sector.updateRemovalDate(removalDate);
-        Events.raise(SectorRemovalDateUpdatedEvent.of(sectorId, removalDate));
+        Events.raise(SectorRemovalDateUpdatedEvent.of(sectorId, removalDate, sector.isExpired()));
         return SectorDetailResponseDto.toDto(sector);
     }
 

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
@@ -3,11 +3,15 @@ package com.first.flash.climbing.sector.application;
 import com.first.flash.climbing.gym.domian.ClimbingGymIdConfirmRequestedEvent;
 import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorDetailResponseDto;
+import com.first.flash.climbing.sector.application.dto.SectorInfoCreateRequestDto;
+import com.first.flash.climbing.sector.application.dto.SectorInfoDetailResponseDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRemovalDateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorsDetailResponseDto;
 import com.first.flash.climbing.sector.domain.Sector;
 import com.first.flash.climbing.sector.domain.SectorExpiredEvent;
+import com.first.flash.climbing.sector.domain.SectorInfo;
+import com.first.flash.climbing.sector.domain.SectorInfoRepository;
 import com.first.flash.climbing.sector.domain.SectorInfoUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
 import com.first.flash.climbing.sector.domain.SectorRepository;
@@ -26,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SectorService {
 
     private final SectorRepository sectorRepository;
+    private final SectorInfoRepository sectorInfoRepository;
 
     @Transactional
     public SectorDetailResponseDto saveSector(final Long gymId,
@@ -35,6 +40,15 @@ public class SectorService {
         Events.raise(ClimbingGymIdConfirmRequestedEvent.of(gymId));
 
         return SectorDetailResponseDto.toDto(sectorRepository.save(sector));
+    }
+    
+    @Transactional
+    public SectorInfoDetailResponseDto saveSectorInfo(final Long gymId,
+        final SectorInfoCreateRequestDto createRequestDto) {
+        SectorInfo sectorInfo = SectorInfo.createDefault(createRequestDto.name(),
+            createRequestDto.adminName(), gymId, createRequestDto.selectedImageUrl());
+        Events.raise(ClimbingGymIdConfirmRequestedEvent.of(gymId));
+        return SectorInfoDetailResponseDto.toDto(sectorInfoRepository.save(sectorInfo));
     }
 
     @Transactional
@@ -58,9 +72,9 @@ public class SectorService {
         final Long sectorId,
         final SectorUpdateRequestDto updateRequestDto) {
         Sector foundSector = findById(sectorId);
-        foundSector.updateSector(updateRequestDto.sectorName(), updateRequestDto.adminSectorName(),
-            updateRequestDto.settingDate(),
-            updateRequestDto.removalDate(), updateRequestDto.gymId());
+//        foundSector.updateSector(updateRequestDto.sectorName(), updateRequestDto.adminSectorName(),
+//            updateRequestDto.settingDate(),
+//            updateRequestDto.removalDate(), updateRequestDto.gymId());
         Events.raise(SectorInfoUpdatedEvent.of(foundSector.getId(), updateRequestDto.sectorName(),
             updateRequestDto.settingDate()));
         Events.raise(ClimbingGymIdConfirmRequestedEvent.of(updateRequestDto.gymId()));
@@ -85,13 +99,15 @@ public class SectorService {
     private Sector createSectorByDto(final Long gymId,
         final SectorCreateRequestDto createRequestDto) {
         if (hasNoRemovalDate(createRequestDto)) {
-            return Sector.createExceptRemovalDate(createRequestDto.name(),
-                createRequestDto.adminName(), createRequestDto.settingDate(), gymId);
+//            return Sector.createExceptRemovalDate(createRequestDto.name(),
+//                createRequestDto.adminName(), createRequestDto.settingDate(), gymId);
+            return null;
         }
 
-        return Sector.createDefault(createRequestDto.name(),
-            createRequestDto.adminName(), createRequestDto.settingDate(),
-            createRequestDto.removalDate(), gymId);
+//        return Sector.createDefault(createRequestDto.name(),
+//            createRequestDto.adminName(), createRequestDto.settingDate(),
+//            createRequestDto.removalDate(), gymId);
+        return null;
     }
 
     private static boolean hasNoRemovalDate(final SectorCreateRequestDto createRequestDto) {

--- a/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/SectorService.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.sector.application;
 
 import com.first.flash.climbing.gym.domian.ClimbingGymIdConfirmRequestedEvent;
+import com.first.flash.climbing.sector.application.dto.SectorInfosDetailResponseDto;
 import com.first.flash.climbing.sector.infrastructure.dto.UpdateSectorsDto;
 import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorDetailResponseDto;
@@ -105,6 +106,16 @@ public class SectorService {
                 SectorDetailResponseDto::toDto)
             .toList();
         return new SectorsDetailResponseDto(sectorsResponse);
+    }
+
+    public SectorInfosDetailResponseDto findAllSectorInfos() {
+        List<SectorInfoDetailResponseDto> sectorInfosResponse = sectorInfoRepository
+            .findAll()
+            .stream()
+            .map(
+                SectorInfoDetailResponseDto::toDto)
+            .toList();
+        return new SectorInfosDetailResponseDto(sectorInfosResponse);
     }
 
     private Sector createSector(final SectorInfo sectorInfo,

--- a/src/main/java/com/first/flash/climbing/sector/application/dto/SectorCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/dto/SectorCreateRequestDto.java
@@ -1,12 +1,9 @@
 package com.first.flash.climbing.sector.application.dto;
 
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 
 public record SectorCreateRequestDto(
-    @NotEmpty(message = "섹터 이름은 필수입니다.") String name,
-    @NotEmpty(message = "섹터 관리 이름은 필수입니다.") String adminName,
     @NotNull(message = "세팅일 정보는 비어있을 수 없습니다.") LocalDate settingDate,
     LocalDate removalDate) {
 

--- a/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfoCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfoCreateRequestDto.java
@@ -1,5 +1,9 @@
 package com.first.flash.climbing.sector.application.dto;
 
-public record SectorInfoCreateRequestDto(String name, String adminName, String selectedImageUrl) {
+import jakarta.validation.constraints.NotEmpty;
+
+public record SectorInfoCreateRequestDto(@NotEmpty(message = "섹터 이름은 필수입니다.") String name,
+                                         @NotEmpty(message = "섹터 관리 이름은 필수입니다.") String adminName,
+                                         String selectedImageUrl) {
 
 }

--- a/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfoCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfoCreateRequestDto.java
@@ -1,0 +1,5 @@
+package com.first.flash.climbing.sector.application.dto;
+
+public record SectorInfoCreateRequestDto(String name, String adminName, String selectedImageUrl) {
+
+}

--- a/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfoDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfoDetailResponseDto.java
@@ -1,0 +1,13 @@
+package com.first.flash.climbing.sector.application.dto;
+
+import com.first.flash.climbing.sector.domain.SectorInfo;
+import com.first.flash.climbing.sector.domain.vo.SectorName;
+
+public record SectorInfoDetailResponseDto(Long id, SectorName sectorName, String selectedImageUrl,
+                                          Long gymId) {
+
+    public static SectorInfoDetailResponseDto toDto(final SectorInfo sectorInfo) {
+        return new SectorInfoDetailResponseDto(sectorInfo.getId(), sectorInfo.getSectorName(),
+            sectorInfo.getSelectedImageUrl(), sectorInfo.getGymId());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfosDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/dto/SectorInfosDetailResponseDto.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.sector.application.dto;
+
+import java.util.List;
+
+public record SectorInfosDetailResponseDto(List<SectorInfoDetailResponseDto> sectorInfosResponse) {
+
+    public static SectorInfosDetailResponseDto toDto(
+        final List<SectorInfoDetailResponseDto> sectorInfosResponse) {
+        return new SectorInfosDetailResponseDto(sectorInfosResponse);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/application/dto/SectorUpdateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/sector/application/dto/SectorUpdateRequestDto.java
@@ -9,11 +9,6 @@ public record SectorUpdateRequestDto(
     @NotEmpty(message = "섹터 관리 이름은 필수입니다.") String adminSectorName,
     @NotNull(message = "세팅일 정보는 비어있을 수 없습니다.") LocalDate settingDate,
     @NotNull(message = "탈거일 정보는 비어있을 수 없습니다.") LocalDate removalDate,
-    @NotNull(message = "클라이밍장 ID는 비어있을 수 없습니다.") Long gymId) {
+    String selectedImageUrl) {
 
-    public static SectorUpdateRequestDto of(final String sectorName, final String adminSectorName,
-        final LocalDate settingDate, final LocalDate removalDate, final Long gymId) {
-        return new SectorUpdateRequestDto(sectorName, adminSectorName, settingDate, removalDate,
-            gymId);
-    }
 }

--- a/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
@@ -31,41 +31,44 @@ public class Sector {
     private RemovalInfo removalInfo;
     private String selectedImageUrl;
     private Long gymId;
+    private Long sectorInfoId;
 
     protected Sector(final SectorName sectorName, final LocalDate settingDate,
-        final RemovalInfo removalInfo, final Long gymId, final String selectedImageUrl) {
+        final RemovalInfo removalInfo, final Long gymId, final String selectedImageUrl,
+        final Long sectorInfoId) {
         this.sectorName = sectorName;
         this.settingDate = settingDate;
         this.removalInfo = removalInfo;
         this.selectedImageUrl = selectedImageUrl;
         this.gymId = gymId;
+        this.sectorInfoId = sectorInfoId;
     }
 
     public static Sector of(final SectorName sectorName, final LocalDate settingDate,
         final LocalDate removalDate, final Long gymId,
-        final String selectedImageUrl) {
+        final String selectedImageUrl, final Long sectorInfoId) {
         if (hasNoRemovalDate(removalDate)) {
             return createExceptRemovalDate(sectorName.getName(), sectorName.getAdminName(),
-                settingDate, gymId, selectedImageUrl);
+                settingDate, gymId, selectedImageUrl, sectorInfoId);
         }
 
         return createDefault(sectorName.getName(), sectorName.getAdminName(), settingDate,
-            removalDate, gymId, selectedImageUrl);
+            removalDate, gymId, selectedImageUrl, sectorInfoId);
     }
 
     public static Sector createExceptRemovalDate(final String sectorName,
         final String adminSectorName, final LocalDate settingDate, final Long gymId,
-        final String selectedImageUrl) {
+        final String selectedImageUrl, final Long sectorInfoId) {
         return new Sector(SectorName.of(sectorName, adminSectorName), settingDate,
-            RemovalInfo.createBySettingDate(settingDate), gymId, selectedImageUrl);
+            RemovalInfo.createBySettingDate(settingDate), gymId, selectedImageUrl, sectorInfoId);
     }
 
     public static Sector createDefault(final String sectorName, final String adminSectorName,
         final LocalDate settingDate, final LocalDate removalDate, final Long gymId,
-        final String selectedImageUrl) {
+        final String selectedImageUrl, final Long sectorInfoId) {
         validateRemovalDate(settingDate, removalDate);
         return new Sector(SectorName.of(sectorName, adminSectorName), settingDate,
-            RemovalInfo.createDefault(removalDate), gymId, selectedImageUrl);
+            RemovalInfo.createDefault(removalDate), gymId, selectedImageUrl, sectorInfoId);
     }
 
     public LocalDate getRemovalDate() {
@@ -78,14 +81,16 @@ public class Sector {
     }
 
     public void updateSector(final String sectorName, final String adminSectorName,
-        final LocalDate settingDate, final LocalDate removalDate, final Long gymId,
-        final String selectedImageUrl) {
+        final LocalDate settingDate, final LocalDate removalDate, final String selectedImageUrl) {
         validateRemovalDate(settingDate, removalDate);
         this.sectorName = SectorName.of(sectorName, adminSectorName);
         this.settingDate = settingDate;
-        this.removalInfo = RemovalInfo.createDefault(removalDate);
+        this.removalInfo = RemovalInfo.createByNewRemovalDate(removalDate);
         this.selectedImageUrl = selectedImageUrl;
-        this.gymId = gymId;
+    }
+
+    public boolean isExpired() {
+        return removalInfo.getIsExpired();
     }
 
     private static void validateRemovalDate(final LocalDate settingDate,

--- a/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
@@ -8,7 +8,9 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.time.LocalDate;
+import java.util.Objects;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -17,6 +19,7 @@ import lombok.ToString;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 @ToString
 public class Sector {
 
@@ -36,6 +39,18 @@ public class Sector {
         this.removalInfo = removalInfo;
         this.selectedImageUrl = selectedImageUrl;
         this.gymId = gymId;
+    }
+
+    public static Sector of(final SectorName sectorName, final LocalDate settingDate,
+        final LocalDate removalDate, final Long gymId,
+        final String selectedImageUrl) {
+        if (hasNoRemovalDate(removalDate)) {
+            return createExceptRemovalDate(sectorName.getName(), sectorName.getAdminName(),
+                settingDate, gymId, selectedImageUrl);
+        }
+
+        return createDefault(sectorName.getName(), sectorName.getAdminName(), settingDate,
+            removalDate, gymId, selectedImageUrl);
     }
 
     public static Sector createExceptRemovalDate(final String sectorName,
@@ -78,5 +93,9 @@ public class Sector {
         if (removalDate.isBefore(settingDate)) {
             throw new InvalidRemovalDateException();
         }
+    }
+
+    private static boolean hasNoRemovalDate(final LocalDate removalDate) {
+        return Objects.isNull(removalDate);
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
@@ -23,10 +23,10 @@ public class Sector {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String selectedImageUrl;
     private SectorName sectorName;
     private LocalDate settingDate;
     private RemovalInfo removalInfo;
+    private String selectedImageUrl;
     private Long gymId;
 
     protected Sector(final SectorName sectorName, final LocalDate settingDate,

--- a/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
@@ -23,30 +23,34 @@ public class Sector {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    private String selectedImageUrl;
     private SectorName sectorName;
     private LocalDate settingDate;
     private RemovalInfo removalInfo;
     private Long gymId;
 
     protected Sector(final SectorName sectorName, final LocalDate settingDate,
-        final RemovalInfo removalInfo, final Long gymId) {
+        final RemovalInfo removalInfo, final Long gymId, final String selectedImageUrl) {
         this.sectorName = sectorName;
         this.settingDate = settingDate;
         this.removalInfo = removalInfo;
+        this.selectedImageUrl = selectedImageUrl;
         this.gymId = gymId;
     }
 
     public static Sector createExceptRemovalDate(final String sectorName,
-        final String adminSectorName, final LocalDate settingDate, final Long gymId) {
+        final String adminSectorName, final LocalDate settingDate, final Long gymId,
+        final String selectedImageUrl) {
         return new Sector(SectorName.of(sectorName, adminSectorName), settingDate,
-            RemovalInfo.createBySettingDate(settingDate), gymId);
+            RemovalInfo.createBySettingDate(settingDate), gymId, selectedImageUrl);
     }
 
     public static Sector createDefault(final String sectorName, final String adminSectorName,
-        final LocalDate settingDate, final LocalDate removalDate, final Long gymId) {
+        final LocalDate settingDate, final LocalDate removalDate, final Long gymId,
+        final String selectedImageUrl) {
         validateRemovalDate(settingDate, removalDate);
         return new Sector(SectorName.of(sectorName, adminSectorName), settingDate,
-            RemovalInfo.createDefault(removalDate), gymId);
+            RemovalInfo.createDefault(removalDate), gymId, selectedImageUrl);
     }
 
     public LocalDate getRemovalDate() {
@@ -59,11 +63,13 @@ public class Sector {
     }
 
     public void updateSector(final String sectorName, final String adminSectorName,
-        final LocalDate settingDate, final LocalDate removalDate, final Long gymId) {
+        final LocalDate settingDate, final LocalDate removalDate, final Long gymId,
+        final String selectedImageUrl) {
         validateRemovalDate(settingDate, removalDate);
         this.sectorName = SectorName.of(sectorName, adminSectorName);
         this.settingDate = settingDate;
         this.removalInfo = RemovalInfo.createDefault(removalDate);
+        this.selectedImageUrl = selectedImageUrl;
         this.gymId = gymId;
     }
 

--- a/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/Sector.java
@@ -77,7 +77,7 @@ public class Sector {
 
     public void updateRemovalDate(final LocalDate removalDate) {
         validateRemovalDate(settingDate, removalDate);
-        removalInfo = RemovalInfo.createDefault(removalDate);
+        removalInfo = RemovalInfo.createByNewRemovalDate(removalDate);
     }
 
     public void updateSector(final String sectorName, final String adminSectorName,

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorFixedInfoUpdatedEvent.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorFixedInfoUpdatedEvent.java
@@ -1,6 +1,5 @@
-package com.first.flash.climbing.sector.application;
+package com.first.flash.climbing.sector.domain;
 
-import com.first.flash.climbing.sector.domain.SectorInfo;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorInfo.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorInfo.java
@@ -1,0 +1,45 @@
+package com.first.flash.climbing.sector.domain;
+
+import com.first.flash.climbing.sector.domain.vo.SectorName;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+public class SectorInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String selectedImageUrl;
+    private SectorName sectorName;
+    private Long gymId;
+
+    protected SectorInfo(final String selectedImageUrl, final SectorName sectorName,
+        final Long gymId) {
+        this.selectedImageUrl = selectedImageUrl;
+        this.sectorName = sectorName;
+        this.gymId = gymId;
+    }
+
+    public static SectorInfo createDefault(final String sectorName, final String adminSectorName,
+        final Long gymId, final String selectedImageUrl) {
+        return new SectorInfo(selectedImageUrl, SectorName.of(sectorName, adminSectorName), gymId);
+    }
+
+    public void updateSectorInfo(final String sectorName, final String adminSectorName,
+        final Long gymId, final String selectedImageUrl) {
+        this.sectorName = SectorName.of(sectorName, adminSectorName);
+        this.selectedImageUrl = selectedImageUrl;
+        this.gymId = gymId;
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorInfo.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorInfo.java
@@ -37,9 +37,8 @@ public class SectorInfo {
     }
 
     public void updateSectorInfo(final String sectorName, final String adminSectorName,
-        final Long gymId, final String selectedImageUrl) {
+        final String selectedImageUrl) {
         this.sectorName = SectorName.of(sectorName, adminSectorName);
         this.selectedImageUrl = selectedImageUrl;
-        this.gymId = gymId;
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorInfoRepository.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorInfoRepository.java
@@ -1,0 +1,13 @@
+package com.first.flash.climbing.sector.domain;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface SectorInfoRepository {
+
+    SectorInfo save(SectorInfo sectorInfo);
+
+    Optional<SectorInfo> findById(Long id);
+
+    List<SectorInfo> findAll();
+}

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorInfoUpdatedEvent.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorInfoUpdatedEvent.java
@@ -11,9 +11,10 @@ public class SectorInfoUpdatedEvent {
     private Long id;
     private String sectorName;
     private LocalDate settingDate;
+    private boolean isExpired;
 
     public static SectorInfoUpdatedEvent of(final Long id, final String sectorName,
-        final LocalDate settingDate) {
-        return new SectorInfoUpdatedEvent(id, sectorName, settingDate);
+        final LocalDate settingDate, final boolean isExpired) {
+        return new SectorInfoUpdatedEvent(id, sectorName, settingDate, isExpired);
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorRemovalDateUpdatedEvent.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorRemovalDateUpdatedEvent.java
@@ -11,9 +11,10 @@ public class SectorRemovalDateUpdatedEvent extends Event {
 
     private Long sectorId;
     private LocalDate removalDate;
+    private boolean isExpired;
 
     public static SectorRemovalDateUpdatedEvent of(
-        final Long sectorId, final LocalDate removalDate) {
-        return new SectorRemovalDateUpdatedEvent(sectorId, removalDate);
+        final Long sectorId, final LocalDate removalDate, final boolean isExpired) {
+        return new SectorRemovalDateUpdatedEvent(sectorId, removalDate, isExpired);
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/domain/SectorRepository.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/SectorRepository.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.sector.domain;
 
+import com.first.flash.climbing.sector.infrastructure.dto.UpdateSectorsDto;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +13,8 @@ public interface SectorRepository {
     List<Long> updateExpiredSector();
 
     List<Sector> findAll();
+
+    void updateSectors(final Long sectorInfoId, final UpdateSectorsDto updateSectorsDto);
+
+    List<Long> findSectorIdsBySectorInfoId(Long sectorInfoId);
 }

--- a/src/main/java/com/first/flash/climbing/sector/domain/vo/RemovalInfo.java
+++ b/src/main/java/com/first/flash/climbing/sector/domain/vo/RemovalInfo.java
@@ -35,4 +35,11 @@ public class RemovalInfo {
     public static RemovalInfo createDefault(final LocalDate removalDate) {
         return new RemovalInfo(removalDate, false, false);
     }
+
+    public static RemovalInfo createByNewRemovalDate(final LocalDate removalDate) {
+        if (removalDate.isBefore(LocalDate.now())) {
+            return new RemovalInfo(removalDate, false, true);
+        }
+        return new RemovalInfo(removalDate, false, false);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/sector/exception/SectorExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/sector/exception/SectorExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.sector.exception;
 
 import com.first.flash.climbing.sector.exception.exceptions.InvalidRemovalDateException;
+import com.first.flash.climbing.sector.exception.exceptions.SectorInfoNotFoundException;
 import com.first.flash.climbing.sector.exception.exceptions.SectorNotFoundException;
 import com.first.flash.global.dto.ErrorResponseDto;
 import org.springframework.http.HttpStatus;
@@ -14,6 +15,12 @@ public class SectorExceptionHandler {
     @ExceptionHandler(SectorNotFoundException.class)
     public ResponseEntity<ErrorResponseDto> handleSectorNotFoundException(
         final SectorNotFoundException exception) {
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
+    }
+
+    @ExceptionHandler(SectorInfoNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleSectorInfoNotFoundException(
+        final SectorInfoNotFoundException exception) {
         return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
     }
 

--- a/src/main/java/com/first/flash/climbing/sector/exception/exceptions/SectorInfoNotFoundException.java
+++ b/src/main/java/com/first/flash/climbing/sector/exception/exceptions/SectorInfoNotFoundException.java
@@ -1,0 +1,8 @@
+package com.first.flash.climbing.sector.exception.exceptions;
+
+public class SectorInfoNotFoundException extends RuntimeException {
+
+    public SectorInfoNotFoundException(final Long id) {
+        super(String.format("아이디가 %s인 섹터 정보를 찾을 수 없습니다.", id));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorInfoJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorInfoJpaRepository.java
@@ -1,0 +1,15 @@
+package com.first.flash.climbing.sector.infrastructure;
+
+import com.first.flash.climbing.sector.domain.SectorInfo;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SectorInfoJpaRepository extends JpaRepository<SectorInfo, Long> {
+
+    SectorInfo save(final SectorInfo sector);
+
+    Optional<SectorInfo> findById(final Long id);
+
+    List<SectorInfo> findAll();
+}

--- a/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorInfoRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorInfoRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.first.flash.climbing.sector.infrastructure;
+
+import com.first.flash.climbing.sector.domain.SectorInfo;
+import com.first.flash.climbing.sector.domain.SectorInfoRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class SectorInfoRepositoryImpl implements SectorInfoRepository {
+
+    private final SectorInfoJpaRepository jpaRepository;
+
+    @Override
+    public SectorInfo save(final SectorInfo sectorInfo) {
+        return jpaRepository.save(sectorInfo);
+    }
+
+    @Override
+    public Optional<SectorInfo> findById(final Long id) {
+        return jpaRepository.findById(id);
+    }
+
+    @Override
+    public List<SectorInfo> findAll() {
+        return jpaRepository.findAll();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorQueryDslRepository.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.sector.infrastructure;
 
 import static com.first.flash.climbing.sector.domain.QSector.sector;
 
+import com.first.flash.climbing.sector.infrastructure.dto.UpdateSectorsDto;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
@@ -36,5 +37,22 @@ public class SectorQueryDslRepository {
                                            .and(
                                                sector.removalInfo.removalDate
                                                    .before(LocalDate.now()));
+    }
+
+    public void updateSectors(final Long sectorInfoId,
+        final UpdateSectorsDto updateSectorsDto) {
+        List<Long> sectorIds = findSectorIdsBySectorInfoId(sectorInfoId);
+        jpaQueryFactory.update(sector)
+                       .set(sector.sectorName.name, updateSectorsDto.name())
+                       .set(sector.sectorName.adminName, updateSectorsDto.adminName())
+                       .where(sector.id.in(sectorIds))
+                       .execute();
+    }
+
+    public List<Long> findSectorIdsBySectorInfoId(final Long sectorInfoId) {
+        return jpaQueryFactory.select(sector.id)
+                              .from(sector)
+                              .where(sector.sectorInfoId.eq(sectorInfoId))
+                              .fetch();
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/sector/infrastructure/SectorRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.sector.infrastructure;
 
 import com.first.flash.climbing.sector.domain.Sector;
 import com.first.flash.climbing.sector.domain.SectorRepository;
+import com.first.flash.climbing.sector.infrastructure.dto.UpdateSectorsDto;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +33,16 @@ public class SectorRepositoryImpl implements SectorRepository {
     @Override
     public List<Sector> findAll() {
         return sectorJpaRepository.findAll();
+    }
+
+    @Override
+    public void updateSectors(final Long sectorInfoId,
+        final UpdateSectorsDto updateSectorsDto) {
+        sectorQueryDslRepository.updateSectors(sectorInfoId, updateSectorsDto);
+    }
+
+    @Override
+    public List<Long> findSectorIdsBySectorInfoId(final Long sectorInfoId) {
+        return sectorQueryDslRepository.findSectorIdsBySectorInfoId(sectorInfoId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/infrastructure/dto/UpdateSectorsDto.java
+++ b/src/main/java/com/first/flash/climbing/sector/infrastructure/dto/UpdateSectorsDto.java
@@ -1,0 +1,11 @@
+package com.first.flash.climbing.sector.infrastructure.dto;
+
+import com.first.flash.climbing.sector.domain.SectorInfo;
+
+public record UpdateSectorsDto(String name, String adminName, String selectedImageUrl) {
+
+    public static UpdateSectorsDto toDto(final SectorInfo sectorInfo) {
+        return new UpdateSectorsDto(sectorInfo.getSectorName().getName(),
+            sectorInfo.getSectorName().getAdminName(), sectorInfo.getSelectedImageUrl());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
+++ b/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
@@ -5,6 +5,7 @@ import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorDetailResponseDto;
 import com.first.flash.climbing.sector.application.dto.SectorInfoCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorInfoDetailResponseDto;
+import com.first.flash.climbing.sector.application.dto.SectorInfosDetailResponseDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRemovalDateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorsDetailResponseDto;
@@ -46,6 +47,16 @@ public class SectorController {
         return ResponseEntity.ok(sectorService.findAllSectors());
     }
 
+    @Operation(summary = "모든 섹터 고정 정보 조회", description = "모든 섹터 정보를 리스트로 반환")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 섹터를 조회",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SectorInfosDetailResponseDto.class))),
+    })
+    @GetMapping("sectors")
+    public ResponseEntity<SectorInfosDetailResponseDto> findAllSectorInfos() {
+        return ResponseEntity.ok(sectorService.findAllSectorInfos());
+    }
+
     @Operation(summary = "섹터 고정 정보 생성", description = "특정 클라이밍장의 새로운 섹터 고정 정보 생성")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "성공적으로 섹터를 생성함",
@@ -81,7 +92,7 @@ public class SectorController {
                 @ExampleObject(name = "클라이밍장 없음", value = "{\"error\": \"아이디가 1인 클라이밍장을 찾을 수 없습니다.\"}")
             }))
     })
-    @PostMapping("admin/sectorInfos/{sectorInfoId}")
+    @PostMapping("admin/sectorInfos/{sectorInfoId}/sectors")
     public ResponseEntity<SectorDetailResponseDto> createSector(
         @PathVariable final Long sectorInfoId,
         @Valid @RequestBody final SectorCreateRequestDto sectorCreateRequestDto) {

--- a/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
+++ b/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
@@ -52,7 +52,7 @@ public class SectorController {
         @ApiResponse(responseCode = "200", description = "성공적으로 섹터를 조회",
             content = @Content(mediaType = "application/json", schema = @Schema(implementation = SectorInfosDetailResponseDto.class))),
     })
-    @GetMapping("sectors")
+    @GetMapping("sectorInfos")
     public ResponseEntity<SectorInfosDetailResponseDto> findAllSectorInfos() {
         return ResponseEntity.ok(sectorService.findAllSectorInfos());
     }

--- a/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
+++ b/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
@@ -82,7 +82,8 @@ public class SectorController {
             }))
     })
     @PostMapping("admin/sectorInfos/{sectorInfoId}")
-    public ResponseEntity<SectorDetailResponseDto> createSector(@PathVariable final Long sectorInfoId,
+    public ResponseEntity<SectorDetailResponseDto> createSector(
+        @PathVariable final Long sectorInfoId,
         @Valid @RequestBody final SectorCreateRequestDto sectorCreateRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
                              .body(sectorService.saveSector(sectorInfoId, sectorCreateRequestDto));
@@ -123,7 +124,6 @@ public class SectorController {
         @ApiResponse(responseCode = "404", description = "리소스를 찾을 수 없음",
             content = @Content(mediaType = "application/json", examples = {
                 @ExampleObject(name = "섹터 없음", value = "{\"error\": \"아이디가 1인 섹터를 찾을 수 없습니다.\"}"),
-                @ExampleObject(name = "클라이밍장 없음", value = "{\"error\": \"아이디가 1인 클라이밍장을 찾을 수 없습니다.\"}")
             }))
     })
     @PutMapping("admin/sectors/{sectorId}")
@@ -131,5 +131,25 @@ public class SectorController {
         @PathVariable final Long sectorId,
         @Valid @RequestBody final SectorUpdateRequestDto updateRequestDto) {
         return ResponseEntity.ok(sectorService.updateSector(sectorId, updateRequestDto));
+    }
+
+    @Operation(summary = "섹터 전체 수정", description = "특정 섹터의 정보 수정")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 섹터 정보 수정함",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SectorInfoDetailResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "요청값 누락", value = "{\"name\": \"섹터 이름은 필수입니다.\"}"),
+            })),
+        @ApiResponse(responseCode = "404", description = "리소스를 찾을 수 없음",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "섹터 없음", value = "{\"error\": \"아이디가 1인 섹터 정보를 찾을 수 없습니다.\"}"),
+            }))
+    })
+    @PutMapping("admin/sectorInfos/{sectorInfoId}")
+    public ResponseEntity<SectorInfoDetailResponseDto> updateSectorInfo(
+        @PathVariable final Long sectorInfoId,
+        @Valid @RequestBody final SectorInfoCreateRequestDto updateRequestDto) {
+        return ResponseEntity.ok(sectorService.updateSectorInfo(sectorInfoId, updateRequestDto));
     }
 }

--- a/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
+++ b/src/main/java/com/first/flash/climbing/sector/ui/SectorController.java
@@ -3,6 +3,8 @@ package com.first.flash.climbing.sector.ui;
 import com.first.flash.climbing.sector.application.SectorService;
 import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorDetailResponseDto;
+import com.first.flash.climbing.sector.application.dto.SectorInfoCreateRequestDto;
+import com.first.flash.climbing.sector.application.dto.SectorInfoDetailResponseDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRemovalDateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorUpdateRequestDto;
 import com.first.flash.climbing.sector.application.dto.SectorsDetailResponseDto;
@@ -44,6 +46,27 @@ public class SectorController {
         return ResponseEntity.ok(sectorService.findAllSectors());
     }
 
+    @Operation(summary = "섹터 고정 정보 생성", description = "특정 클라이밍장의 새로운 섹터 고정 정보 생성")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "성공적으로 섹터를 생성함",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = SectorInfoDetailResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "요청값 누락", value = "{\"name\": \"섹터 이름은 필수입니다.\"}"),
+            })),
+        @ApiResponse(responseCode = "404", description = "클라이밍장을 찾을 수 없음",
+            content = @Content(mediaType = "application/json", examples = {
+                @ExampleObject(name = "클라이밍장 없음", value = "{\"error\": \"아이디가 1인 클라이밍장을 찾을 수 없습니다.\"}")
+            }))
+    })
+    @PostMapping("admin/gyms/{gymId}/sectorInfos")
+    public ResponseEntity<SectorInfoDetailResponseDto> createSectorInfo(
+        @PathVariable final Long gymId,
+        @Valid @RequestBody final SectorInfoCreateRequestDto sectorInfoCreateRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(sectorService.saveSectorInfo(gymId, sectorInfoCreateRequestDto));
+    }
+
     @Operation(summary = "섹터 갱신(생성)", description = "특정 클라이밍장에 새로운 섹터 생성")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "성공적으로 섹터를 생성함",
@@ -58,11 +81,11 @@ public class SectorController {
                 @ExampleObject(name = "클라이밍장 없음", value = "{\"error\": \"아이디가 1인 클라이밍장을 찾을 수 없습니다.\"}")
             }))
     })
-    @PostMapping("admin/gyms/{gymId}/sectors")
-    public ResponseEntity<SectorDetailResponseDto> createSector(@PathVariable final Long gymId,
+    @PostMapping("admin/sectorInfos/{sectorInfoId}")
+    public ResponseEntity<SectorDetailResponseDto> createSector(@PathVariable final Long sectorInfoId,
         @Valid @RequestBody final SectorCreateRequestDto sectorCreateRequestDto) {
         return ResponseEntity.status(HttpStatus.CREATED)
-                             .body(sectorService.saveSector(gymId, sectorCreateRequestDto));
+                             .body(sectorService.saveSector(sectorInfoId, sectorCreateRequestDto));
     }
 
     @Operation(summary = "섹터 탈거일 수정", description = "특정 섹터의 탈거일 정보 수정")

--- a/src/test/java/com/first/flash/climbing/sector/domain/SectorTest.java
+++ b/src/test/java/com/first/flash/climbing/sector/domain/SectorTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 class SectorTest {
 
+    private static final String DEFAULT_SECTOR_IMAGE = "example image url";
     private static final Long DEFAULT_GYM_ID = 1L;
 
     @Test
@@ -18,7 +19,7 @@ class SectorTest {
 
         // when & then
         assertThatThrownBy(() -> Sector.createDefault("test", "test", settingDate,
-            settingDate.minusDays(1), DEFAULT_GYM_ID))
+            settingDate.minusDays(1), DEFAULT_GYM_ID, DEFAULT_SECTOR_IMAGE))
             .isInstanceOf(InvalidRemovalDateException.class);
     }
 
@@ -27,7 +28,7 @@ class SectorTest {
         // given
         LocalDate settingDate = LocalDate.now();
         Sector sector = Sector.createExceptRemovalDate("test", "test", settingDate,
-            DEFAULT_GYM_ID);
+            DEFAULT_GYM_ID, DEFAULT_SECTOR_IMAGE);
 
         // when
         sector.updateRemovalDate(settingDate.plusDays(1));
@@ -42,7 +43,7 @@ class SectorTest {
         // given
         LocalDate settingDate = LocalDate.now();
         Sector sector = Sector.createExceptRemovalDate("test", "test", settingDate,
-            DEFAULT_GYM_ID);
+            DEFAULT_GYM_ID, DEFAULT_SECTOR_IMAGE);
 
         // when & then
         assertThatThrownBy(() -> sector.updateRemovalDate(settingDate.minusDays(1)))

--- a/src/test/java/com/first/flash/climbing/sector/fixture/SectorFixture.java
+++ b/src/test/java/com/first/flash/climbing/sector/fixture/SectorFixture.java
@@ -6,17 +6,18 @@ import java.time.LocalDate;
 
 public class SectorFixture {
 
+    private static final String DEFAULT_SECTOR_IMAGE = "example image url";
     private final static Long DEFAULT_PLUS_DAYS = 30L;
 
     public static Sector createDefault(final Long gymId, final LocalDate settingDate) {
         return Sector.createDefault("sector 1", "admin sector 1",
-            settingDate, settingDate.plusDays(DEFAULT_PLUS_DAYS), gymId);
+            settingDate, settingDate.plusDays(DEFAULT_PLUS_DAYS), gymId, DEFAULT_SECTOR_IMAGE);
     }
 
     public static Sector createDefaultExceptRemovalDate(final Long gymId,
         final LocalDate settingDate) {
         return Sector.createExceptRemovalDate("sector 1", "admin sector 1",
-            settingDate, gymId);
+            settingDate, gymId, DEFAULT_SECTOR_IMAGE);
     }
 
     public static SectorCreateRequestDto createDefaultRequestDtoExceptRemovalDate(


### PR DESCRIPTION
# 요약
섹터의 고정적인 정보를 가지는 테이블과 변하는 정보를 가지는 테이블 분리했습니다.
- 고정적인 정보: 선택 이미지, 이름, 어드민 이름, pk, fk
    - 클라이밍장에 포함되는 테이블이 아닌 새로운 테이블
- 가변 정보: 탈거일, 세팅일, 탈거일이 가짜인지 여부, 만료 여부
위 변경 사항에 맞게 기존 API를 수정했습니다. 

수정 시 섹터의 고정 정보, 섹터의 가변 정보, 문제 조회 모델의 관계는 아래와 같습니다.
<img width="887" alt="image" src="https://github.com/user-attachments/assets/49210ec4-19df-432e-9bfa-070db5490a54">


# ERD
<img width="477" alt="image" src="https://github.com/user-attachments/assets/706cf652-110a-4212-92be-f27ac23e44a6">

고정 정보를 SectorInfo 테이블로 분리했습니다.
해당 섹터가 선택되었을 때 이미지 url을 sector에도 반정규화했고, 고정 섹터 정보의 fk를 가지도록 했습니다.

# API
수정한 API는 다음과 같습니다.

## 조회
### /admin/gyms/{gymId} (GET)
- 클라이밍 정보 조회 API
클라이밍장 정보 조회 API는 해당 섹터가 선택되었을 때 imageUrl도 추가로 보내줘야 하기 때문에 요구사항을 만족하도록 했습니다.

```java
public record ClimbingGymDetailResponseDto(String gymName, String mapImageUrl,
                                           String calendarImageUrl,
                                           List<String> difficulties,
                                           List<SectorInfoResponseDto> sectors) {

}
```
원래 섹터 정보는 이름만 반환했지만, 위처럼 SectorInfoResponseDto가 추가되었고 sector가 선택되었을 때 지도 이미지 url가 추가되었습니다.

```java
public record SectorInfoResponseDto(String name, String selectedImageUrl) {

}
```
### /sectorInfos (GET)
- 모든 섹터 고정 정보 조회 API
섹터의 고정 정보가 정규화됨에 따라 모든 고정 정보들을 불러오는 API를 추가했습니다.
```java
public record SectorInfoDetailResponseDto(Long id, SectorName sectorName, String selectedImageUrl,
                                          Long gymId) {

}
```
각 고정 정보 dto에는 위처럼 세팅 정보를 제외한 고정 정보들을 담고 있습니다.

## 생성
### /admin/sectorInfos/{sectorInfoId}/sectors (POST)
- 섹터 갱신(생성) API
섹터 가변 정보는 이제 섹터 고정 정보로부터 파생되기 때문에 gym이 아닌 sectorInfos의 하위 계층에 있도록 API를 변경했습니다.

### /admin/gyms/{gymId}/sectorInfos (POST)
- 섹터 고정 정보 생성 API

섹터의 고정 정보를 생성하는 API를 만들었습니다.

## 수정
### /admin/sectors/{sectorId} (PATCH)
- 섹터 탈거일 수정 API
섹터의 탈거일을 수정하면, 수정될 탈거일을 통해 만료 여부를 다시 판단하도록 수정했습니다.
또한 다시 설정된 만료 여부가 조회 모델에 반영되도록 했습니다.

### /admin/sectors/{sectorId} (PUT)
- 섹터 전체 수정 API
섹터를 수정하면, 수정될 탈거일을 통해 만료 여부를 다시 판단하도록 수정했습니다.
또한 변경되는 정보가 해당 터에 포함되는 문제의 조회 모델에 반영되도록 수정했습니다.

### /admin/sectorInfos/{sectorInfoId} (PUT)
- 섹터 고정 정보 전체 수정 API
섹터의 고정 정보를 수정하면, 해당 고정 정보로부터 파생된 가변 섹터 정보와 해당 가변 섹터에 포함된 문제의 정보가 모두 수정되도록 했고, 이를 벌크 연산으로 처리했습니다.