### PR TITLE
클라이이밍장 즐겨찾기

### DIFF
--- a/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
@@ -5,6 +5,7 @@ import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
 import com.first.flash.global.util.AuthUtil;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,10 +18,15 @@ public class MemberFavoriteGymService {
 
     public MemberFavoriteGymResponseDto saveMemberFavoriteGym(final Long gymId) {
         UUID memberId = AuthUtil.getId();
-        MemberFavoriteGym memberFavoriteGym = MemberFavoriteGym.createDefault(memberId, gymId);
-        MemberFavoriteGym savedMemberFavoriteGym = memberFavoriteGymRepository.save(
-            memberFavoriteGym);
-        return MemberFavoriteGymResponseDto.toDto(savedMemberFavoriteGym);
+        Optional<MemberFavoriteGym> favoriteGym = memberFavoriteGymRepository.findByMemberIdAndGymId(memberId, gymId);
+
+        if (favoriteGym.isPresent()) {
+            memberFavoriteGymRepository.delete(favoriteGym.get());
+        } else {
+            MemberFavoriteGym memberFavoriteGym = MemberFavoriteGym.createDefault(memberId, gymId);
+            memberFavoriteGymRepository.save(memberFavoriteGym);
+        }
+        return MemberFavoriteGymResponseDto.toDtoByStatus(favoriteGym.isPresent());
     }
 
     public List<Long> findFavoriteGymIdsByMemberId(final UUID memberId) {

--- a/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
@@ -3,6 +3,8 @@ package com.first.flash.climbing.favorite.application;
 import com.first.flash.climbing.favorite.application.dto.MemberFavoriteGymResponseDto;
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
+import com.first.flash.climbing.gym.domian.ClimbingGymIdConfirmRequestedEvent;
+import com.first.flash.global.event.Events;
 import com.first.flash.global.util.AuthUtil;
 import java.util.List;
 import java.util.Optional;
@@ -17,6 +19,7 @@ public class MemberFavoriteGymService {
     private final MemberFavoriteGymRepository memberFavoriteGymRepository;
 
     public MemberFavoriteGymResponseDto toggleMemberFavoriteGym(final Long gymId) {
+        Events.raise(ClimbingGymIdConfirmRequestedEvent.of(gymId));
         UUID memberId = AuthUtil.getId();
         Optional<MemberFavoriteGym> favoriteGym = memberFavoriteGymRepository.findByMemberIdAndGymId(memberId, gymId);
 

--- a/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
@@ -16,7 +16,7 @@ public class MemberFavoriteGymService {
 
     private final MemberFavoriteGymRepository memberFavoriteGymRepository;
 
-    public MemberFavoriteGymResponseDto saveMemberFavoriteGym(final Long gymId) {
+    public MemberFavoriteGymResponseDto toggleMemberFavoriteGym(final Long gymId) {
         UUID memberId = AuthUtil.getId();
         Optional<MemberFavoriteGym> favoriteGym = memberFavoriteGymRepository.findByMemberIdAndGymId(memberId, gymId);
 

--- a/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
@@ -1,0 +1,21 @@
+package com.first.flash.climbing.favorite.application;
+
+import com.first.flash.climbing.favorite.application.dto.MemberFavoriteGymResponseDto;
+import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
+import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberFavoriteGymService {
+
+    private final MemberFavoriteGymRepository memberFavoriteGymRepository;
+
+    public MemberFavoriteGymResponseDto saveMemberFavoriteGym(final UUID memberId, final Long gymId) {
+        MemberFavoriteGym memberFavoriteGym = MemberFavoriteGym.createDefault(memberId, gymId);
+        MemberFavoriteGym savedMemberFavoriteGym = memberFavoriteGymRepository.save(memberFavoriteGym);
+        return MemberFavoriteGymResponseDto.toDto(savedMemberFavoriteGym);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
@@ -3,6 +3,7 @@ package com.first.flash.climbing.favorite.application;
 import com.first.flash.climbing.favorite.application.dto.MemberFavoriteGymResponseDto;
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
+import com.first.flash.global.util.AuthUtil;
 import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -14,9 +15,11 @@ public class MemberFavoriteGymService {
 
     private final MemberFavoriteGymRepository memberFavoriteGymRepository;
 
-    public MemberFavoriteGymResponseDto saveMemberFavoriteGym(final UUID memberId, final Long gymId) {
+    public MemberFavoriteGymResponseDto saveMemberFavoriteGym(final Long gymId) {
+        UUID memberId = AuthUtil.getId();
         MemberFavoriteGym memberFavoriteGym = MemberFavoriteGym.createDefault(memberId, gymId);
-        MemberFavoriteGym savedMemberFavoriteGym = memberFavoriteGymRepository.save(memberFavoriteGym);
+        MemberFavoriteGym savedMemberFavoriteGym = memberFavoriteGymRepository.save(
+            memberFavoriteGym);
         return MemberFavoriteGymResponseDto.toDto(savedMemberFavoriteGym);
     }
 

--- a/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/MemberFavoriteGymService.java
@@ -3,6 +3,7 @@ package com.first.flash.climbing.favorite.application;
 import com.first.flash.climbing.favorite.application.dto.MemberFavoriteGymResponseDto;
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,5 +18,11 @@ public class MemberFavoriteGymService {
         MemberFavoriteGym memberFavoriteGym = MemberFavoriteGym.createDefault(memberId, gymId);
         MemberFavoriteGym savedMemberFavoriteGym = memberFavoriteGymRepository.save(memberFavoriteGym);
         return MemberFavoriteGymResponseDto.toDto(savedMemberFavoriteGym);
+    }
+
+    public List<Long> findFavoriteGymIdsByMemberId(final UUID memberId) {
+        return memberFavoriteGymRepository.findByMemberId(memberId).stream()
+                                          .map(MemberFavoriteGym::getGymId)
+                                          .toList();
     }
 }

--- a/src/main/java/com/first/flash/climbing/favorite/application/dto/MemberFavoriteGymResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/dto/MemberFavoriteGymResponseDto.java
@@ -1,0 +1,12 @@
+package com.first.flash.climbing.favorite.application.dto;
+
+import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
+import java.util.UUID;
+
+public record MemberFavoriteGymResponseDto(Long id, Long gymId, UUID memberId) {
+
+    public static MemberFavoriteGymResponseDto toDto(final MemberFavoriteGym memberFavoriteGym) {
+        return new MemberFavoriteGymResponseDto(memberFavoriteGym.getId(),
+            memberFavoriteGym.getGymId(), memberFavoriteGym.getMemberId());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/favorite/application/dto/MemberFavoriteGymResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/favorite/application/dto/MemberFavoriteGymResponseDto.java
@@ -1,12 +1,11 @@
 package com.first.flash.climbing.favorite.application.dto;
 
-import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
-import java.util.UUID;
+public record MemberFavoriteGymResponseDto(String message) {
 
-public record MemberFavoriteGymResponseDto(Long id, Long gymId, UUID memberId) {
-
-    public static MemberFavoriteGymResponseDto toDto(final MemberFavoriteGym memberFavoriteGym) {
-        return new MemberFavoriteGymResponseDto(memberFavoriteGym.getId(),
-            memberFavoriteGym.getGymId(), memberFavoriteGym.getMemberId());
+    public static MemberFavoriteGymResponseDto toDtoByStatus(final boolean present) {
+        if (present) {
+            return new MemberFavoriteGymResponseDto("즐겨찾기에서 제거되었습니다.");
+        }
+        return new MemberFavoriteGymResponseDto("즐겨찾기에 추가되었습니다.");
     }
 }

--- a/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGym.java
+++ b/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGym.java
@@ -1,0 +1,30 @@
+package com.first.flash.climbing.favorite.domain;
+
+import com.first.flash.global.domain.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@ToString
+public class MemberFavoriteGym extends BaseEntity {
+
+    @Id
+    private Long id;
+    private UUID memberId;
+    private Long gymId;
+
+    protected MemberFavoriteGym(final UUID memberId, final Long gymId) {
+        this.memberId = memberId;
+        this.gymId = gymId;
+    }
+
+    public static MemberFavoriteGym createDefault(final UUID memberId, final Long gymId) {
+        return new MemberFavoriteGym(memberId, gymId);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGym.java
+++ b/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGym.java
@@ -2,6 +2,8 @@ package com.first.flash.climbing.favorite.domain;
 
 import com.first.flash.global.domain.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import java.util.UUID;
 import lombok.Getter;
@@ -15,6 +17,7 @@ import lombok.ToString;
 public class MemberFavoriteGym extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
     private UUID memberId;
     private Long gymId;

--- a/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGymRepository.java
@@ -1,0 +1,14 @@
+package com.first.flash.climbing.favorite.domain;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface MemberFavoriteGymRepository {
+
+    MemberFavoriteGym save(final MemberFavoriteGym memberFavoriteGym);
+
+    Optional<MemberFavoriteGym> findById(final Long id);
+
+    List<MemberFavoriteGym> findByMemberId(final UUID memberId);
+}

--- a/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/favorite/domain/MemberFavoriteGymRepository.java
@@ -11,4 +11,8 @@ public interface MemberFavoriteGymRepository {
     Optional<MemberFavoriteGym> findById(final Long id);
 
     List<MemberFavoriteGym> findByMemberId(final UUID memberId);
+
+    Optional<MemberFavoriteGym> findByMemberIdAndGymId(final UUID memberId, final Long gymId);
+
+    void delete(final MemberFavoriteGym memberFavoriteGym);
 }

--- a/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymJpaRepository.java
@@ -1,7 +1,6 @@
 package com.first.flash.climbing.favorite.infrastructure;
 
 import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
-import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,4 +13,8 @@ public interface MemberFavoriteGymJpaRepository extends JpaRepository<MemberFavo
     Optional<MemberFavoriteGym> findById(final Long id);
 
     List<MemberFavoriteGym> findByMemberId(final UUID memberId);
+
+    Optional<MemberFavoriteGym> findByMemberIdAndGymId(final UUID memberId, final Long gymId);
+
+    void delete(final MemberFavoriteGym memberFavoriteGym);
 }

--- a/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymJpaRepository.java
@@ -1,0 +1,17 @@
+package com.first.flash.climbing.favorite.infrastructure;
+
+import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
+import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberFavoriteGymJpaRepository extends JpaRepository<MemberFavoriteGym, Long> {
+
+    MemberFavoriteGym save(final MemberFavoriteGym memberFavoriteGym);
+
+    Optional<MemberFavoriteGym> findById(final Long id);
+
+    List<MemberFavoriteGym> findByMemberId(final UUID memberId);
+}

--- a/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.first.flash.climbing.favorite.infrastructure;
+
+import com.first.flash.climbing.favorite.domain.MemberFavoriteGym;
+import com.first.flash.climbing.favorite.domain.MemberFavoriteGymRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberFavoriteGymRepositoryImpl implements MemberFavoriteGymRepository {
+
+    private final MemberFavoriteGymJpaRepository memberFavoriteGymJpaRepository;
+
+    @Override
+    public MemberFavoriteGym save(final MemberFavoriteGym memberFavoriteGym) {
+        return memberFavoriteGymJpaRepository.save(memberFavoriteGym);
+    }
+
+    @Override
+    public Optional<MemberFavoriteGym> findById(final Long id) {
+        return memberFavoriteGymJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<MemberFavoriteGym> findByMemberId(final UUID memberId) {
+        return memberFavoriteGymJpaRepository.findByMemberId(memberId);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/favorite/infrastructure/MemberFavoriteGymRepositoryImpl.java
@@ -28,4 +28,15 @@ public class MemberFavoriteGymRepositoryImpl implements MemberFavoriteGymReposit
     public List<MemberFavoriteGym> findByMemberId(final UUID memberId) {
         return memberFavoriteGymJpaRepository.findByMemberId(memberId);
     }
+
+    @Override
+    public Optional<MemberFavoriteGym> findByMemberIdAndGymId(final UUID memberId,
+        final Long gymId) {
+        return memberFavoriteGymJpaRepository.findByMemberIdAndGymId(memberId, gymId);
+    }
+
+    @Override
+    public void delete(final MemberFavoriteGym memberFavoriteGym) {
+        memberFavoriteGymJpaRepository.delete(memberFavoriteGym);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
+++ b/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "favorite", description = "즐겨찾기 API")
 @RestController
 @RequiredArgsConstructor
 public class MemberFavoriteGymController {

--- a/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
+++ b/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,6 +27,7 @@ public class MemberFavoriteGymController {
         @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
             content = @Content(mediaType = "application/json"))
     })
+    @PutMapping("/favorites/{gymId}")
     public ResponseEntity<MemberFavoriteGymResponseDto> toggleMemberFavoriteGym(
         @PathVariable final Long gymId) {
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
+++ b/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
@@ -1,0 +1,34 @@
+package com.first.flash.climbing.favorite.ui;
+
+import com.first.flash.climbing.favorite.application.MemberFavoriteGymService;
+import com.first.flash.climbing.favorite.application.dto.MemberFavoriteGymResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class MemberFavoriteGymController {
+
+    private final MemberFavoriteGymService memberFavoriteGymService;
+
+    @Operation(summary = "클라이밍장 즐겨찾기 생성/삭제", description = "클라이밍장 id로 즐겨찾기 토글")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "즐겨찾기 생성 및 삭제",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = MemberFavoriteGymResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "유효하지 않은 요청 형식",
+            content = @Content(mediaType = "application/json"))
+    })
+    public ResponseEntity<MemberFavoriteGymResponseDto> toggleMemberFavoriteGym(
+        @PathVariable final Long gymId) {
+        return ResponseEntity.status(HttpStatus.OK)
+                             .body(memberFavoriteGymService.save(gymId));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
+++ b/src/main/java/com/first/flash/climbing/favorite/ui/MemberFavoriteGymController.java
@@ -29,6 +29,6 @@ public class MemberFavoriteGymController {
     public ResponseEntity<MemberFavoriteGymResponseDto> toggleMemberFavoriteGym(
         @PathVariable final Long gymId) {
         return ResponseEntity.status(HttpStatus.OK)
-                             .body(memberFavoriteGymService.save(gymId));
+                             .body(memberFavoriteGymService.toggleMemberFavoriteGym(gymId));
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -4,7 +4,7 @@ import com.first.flash.climbing.favorite.application.MemberFavoriteGymService;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymDetailResponseDto;
-import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
+import com.first.flash.climbing.gym.infrastructure.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
 import com.first.flash.climbing.gym.domian.vo.Difficulty;
@@ -39,12 +39,7 @@ public class ClimbingGymService {
     public List<ClimbingGymResponseDto> findAllClimbingGyms() {
         UUID memberId = AuthUtil.getId();
         List<Long> favoriteGymIds = memberFavoriteGymService.findFavoriteGymIdsByMemberId(memberId);
-        climbingGymRepository.findAll();
-        return climbingGymRepository.findAll().stream()
-                                    .map(
-                                        gym -> (ClimbingGymResponseDto)
-                                            ClimbingGymResponseDto.toDto(gym, favoriteGymIds))
-                                    .toList();
+        return climbingGymRepository.findAllWithFavorites(favoriteGymIds);
     }
 
     public ClimbingGymDetailResponseDto findClimbingGymDetail(final Long id) {

--- a/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/ClimbingGymService.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.gym.application;
 
+import com.first.flash.climbing.favorite.application.MemberFavoriteGymService;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymDetailResponseDto;
@@ -9,7 +10,9 @@ import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
 import com.first.flash.climbing.gym.domian.vo.Difficulty;
 import com.first.flash.climbing.gym.exception.exceptions.ClimbingGymNotFoundException;
 import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
+import com.first.flash.global.util.AuthUtil;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ClimbingGymService {
 
     private final ClimbingGymRepository climbingGymRepository;
+    private final MemberFavoriteGymService memberFavoriteGymService;
 
     @Transactional
     public ClimbingGymCreateResponseDto save(final ClimbingGymCreateRequestDto createRequestDto) {
@@ -33,8 +37,13 @@ public class ClimbingGymService {
     }
 
     public List<ClimbingGymResponseDto> findAllClimbingGyms() {
+        UUID memberId = AuthUtil.getId();
+        List<Long> favoriteGymIds = memberFavoriteGymService.findFavoriteGymIdsByMemberId(memberId);
+        climbingGymRepository.findAll();
         return climbingGymRepository.findAll().stream()
-                                    .map(ClimbingGymResponseDto::toDto)
+                                    .map(
+                                        gym -> (ClimbingGymResponseDto)
+                                            ClimbingGymResponseDto.toDto(gym, favoriteGymIds))
                                     .toList();
     }
 

--- a/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/application/dto/ClimbingGymResponseDto.java
@@ -1,10 +1,11 @@
 package com.first.flash.climbing.gym.application.dto;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
+import java.util.List;
 
-public record ClimbingGymResponseDto(Long id, String gymName, String thumbnailUrl) {
+public record ClimbingGymResponseDto(Long id, String gymName, String thumbnailUrl, boolean isFavorite) {
 
-    public static ClimbingGymResponseDto toDto(final ClimbingGym gym) {
-        return new ClimbingGymResponseDto(gym.getId(), gym.getGymName(), gym.getThumbnailUrl());
+    public static Object toDto(final ClimbingGym gym, final List<Long> favoriteGymIds) {
+        return new ClimbingGymResponseDto(gym.getId(), gym.getGymName(), gym.getThumbnailUrl(), favoriteGymIds.contains(gym.getId()));
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/domian/ClimbingGymRepository.java
@@ -1,5 +1,6 @@
 package com.first.flash.climbing.gym.domian;
 
+import com.first.flash.climbing.gym.infrastructure.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
 import java.util.List;
 import java.util.Optional;
@@ -10,7 +11,7 @@ public interface ClimbingGymRepository {
 
     Optional<ClimbingGym> findById(final Long id);
 
-    List<ClimbingGym> findAll();
+    List<ClimbingGymResponseDto> findAllWithFavorites(final List<Long> favoriteGymIds);
 
     List<SectorInfoResponseDto> findGymSectorNamesById(final Long id);
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymJpaRepository.java
@@ -1,7 +1,6 @@
 package com.first.flash.climbing.gym.infrastructure;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,6 +9,4 @@ public interface ClimbingGymJpaRepository extends JpaRepository<ClimbingGym, Lon
     ClimbingGym save(final ClimbingGym gym);
 
     Optional<ClimbingGym> findById(final Long id);
-
-    List<ClimbingGym> findAll();
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
@@ -1,9 +1,12 @@
 package com.first.flash.climbing.gym.infrastructure;
 
+import static com.first.flash.climbing.gym.domian.QClimbingGym.climbingGym;
 import static com.first.flash.climbing.sector.domain.QSector.sector;
 
+import com.first.flash.climbing.gym.infrastructure.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +26,21 @@ public class ClimbingGymQueryDslRepository {
                               .where(sector.gymId.eq(gymId), sector.removalInfo.isExpired.isFalse())
                               .distinct()
                               .orderBy(sector.sectorName.name.asc())
+                              .fetch();
+    }
+
+    public List<ClimbingGymResponseDto> findAllWithFavorites(final List<Long> favoriteGymIds) {
+        return jpaQueryFactory.select(
+                                  Projections.constructor(ClimbingGymResponseDto.class, climbingGym.id,
+                                      climbingGym.gymName, climbingGym.thumbnailUrl, climbingGym.id.in(favoriteGymIds))
+                              )
+                              .from(climbingGym)
+                              .orderBy(
+                                  new CaseBuilder()
+                                      .when(climbingGym.id.in(favoriteGymIds)).then(1)
+                                      .otherwise(0).desc(),
+                                  climbingGym.gymName.asc()
+                              )
                               .fetch();
     }
 }

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.gym.infrastructure;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.ClimbingGymRepository;
+import com.first.flash.climbing.gym.infrastructure.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.infrastructure.dto.SectorInfoResponseDto;
 import java.util.List;
 import java.util.Optional;
@@ -26,9 +27,9 @@ public class ClimbingGymRepositoryImpl implements ClimbingGymRepository {
     }
 
     @Override
-    public List<ClimbingGym> findAll() {
-        return climbingGymJpaRepository.findAll();
-    }
+    public List<ClimbingGymResponseDto> findAllWithFavorites(final List<Long> favoriteGymIds){
+        return climbingGymQueryDslRepository.findAllWithFavorites(favoriteGymIds);
+    };
 
     @Override
     public List<SectorInfoResponseDto> findGymSectorNamesById(final Long id) {

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/dto/ClimbingGymResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/dto/ClimbingGymResponseDto.java
@@ -1,4 +1,4 @@
-package com.first.flash.climbing.gym.application.dto;
+package com.first.flash.climbing.gym.infrastructure.dto;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import java.util.List;

--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -4,7 +4,7 @@ import com.first.flash.climbing.gym.application.ClimbingGymService;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateRequestDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymCreateResponseDto;
 import com.first.flash.climbing.gym.application.dto.ClimbingGymDetailResponseDto;
-import com.first.flash.climbing.gym.application.dto.ClimbingGymResponseDto;
+import com.first.flash.climbing.gym.infrastructure.dto.ClimbingGymResponseDto;
 import com.first.flash.climbing.gym.domian.vo.Difficulty;
 import com.first.flash.climbing.gym.exception.exceptions.DuplicateDifficultyLevelException;
 import com.first.flash.climbing.gym.exception.exceptions.DuplicateDifficultyNameException;

--- a/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
+++ b/src/main/java/com/first/flash/climbing/gym/ui/ClimbingGymController.java
@@ -27,7 +27,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "gyms", description = "클라이밍장 조회 API")


### PR DESCRIPTION
# 요약
클라이밍장 - 회원 간 M:N 즐겨찾기 관계 테이블 MemberFavoriteGym으로 만들었습니다. 

이제 회원은 토글 형식으로 하나의 API를 이용해 클라이밍장 즐겨찾기를 설정, 해제할 수 있습니다. 또한 클라이밍장 전체 조회 시 해당 요청을 보낸 회원이 즐겨찾기한 클라이밍장을 우선적으로 보여주며, 그 여부도 필드로 제공합니다.

# 내용

수정/추가한 API는 다음과 같습니다.

### /favorites/{gymId} (PUT)
- 즐겨찾기 토글 API

gymId를 url 파라미터로 보내면, 요청으로 받은 토큰과 해당 gym id로 memberFavoriteGym 데이터를 생성합니다. 이때 이미 유저가 클라이밍장을 즐겨찾기 설정했다면, 데이터가 삭제됩니다.

### /gyms (GET)
- 클라이밍장 전체 조회 API

전체 조회 시 즐겨찾기 여부에 따라 정렬되며, 각 클라이밍장 응답 데이터는 다음과 같습니다.
```java
public record ClimbingGymResponseDto(Long id, String gymName, String thumbnailUrl, boolean isFavorite) {

}
```
isFavorite을 통해 유저가 해당 클라이밍장을 즐겨찾기 했는지 여부를 전달합니다.

## 논의 필요

### 마지막으로 조회한 클라이밍장을 저장하는 방법
- member의 DB 컬럼 추가
- 캐시 서버 이용
- jwt
- 클라이언트에서 저장