### PR TITLE
홀드색 정보 추가 및 조회 API 구현

### DIFF
--- a/src/main/java/com/first/flash/climbing/hold/application/HoldService.java
+++ b/src/main/java/com/first/flash/climbing/hold/application/HoldService.java
@@ -1,0 +1,50 @@
+package com.first.flash.climbing.hold.application;
+
+import com.first.flash.climbing.hold.application.dto.HoldCreateRequestDto;
+import com.first.flash.climbing.hold.application.dto.HoldResponseDto;
+import com.first.flash.climbing.hold.application.dto.HoldsResponseDto;
+import com.first.flash.climbing.hold.domain.Hold;
+import com.first.flash.climbing.hold.domain.HoldRepository;
+import com.first.flash.climbing.hold.exception.exceptions.HoldNotFoundException;
+import com.first.flash.climbing.sector.application.dto.SectorCreateRequestDto;
+import com.first.flash.climbing.sector.application.dto.SectorDetailResponseDto;
+import com.first.flash.climbing.sector.application.dto.SectorsDetailResponseDto;
+import com.first.flash.climbing.sector.domain.Sector;
+import com.first.flash.climbing.sector.domain.SectorInfo;
+import com.first.flash.climbing.sector.exception.exceptions.SectorNotFoundException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HoldService {
+
+    private final HoldRepository holdRepository;
+
+    public Hold findById(final Long id) {
+        return holdRepository.findById(id)
+                             .orElseThrow(() -> new HoldNotFoundException(id));
+    }
+
+    public HoldsResponseDto findAllHolds() {
+        List<HoldResponseDto> holdsResponse = holdRepository.findAll()
+                                         .stream()
+                                         .map(HoldResponseDto::toDto)
+                                         .toList();
+
+        return new HoldsResponseDto(holdsResponse);
+    }
+
+    @Transactional
+    public HoldResponseDto saveHold(final HoldCreateRequestDto createRequestDto) {
+        Hold hold = createHold(createRequestDto);
+        return HoldResponseDto.toDto(holdRepository.save(hold));
+    }
+
+    private Hold createHold(final HoldCreateRequestDto createRequestDto) {
+        return Hold.of(createRequestDto.colorName(), createRequestDto.colorCode());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/hold/application/dto/HoldCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/hold/application/dto/HoldCreateRequestDto.java
@@ -1,0 +1,10 @@
+package com.first.flash.climbing.hold.application.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+
+public record HoldCreateRequestDto(
+    @NotNull(message = "홀드 색상 이름 정보는 비어있을 수 없습니다.") String colorName,
+    @NotNull(message = "홀드 색상 코드 정보는 비어있을 수 없습니다.") String colorCode) {
+
+}

--- a/src/main/java/com/first/flash/climbing/hold/application/dto/HoldResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/hold/application/dto/HoldResponseDto.java
@@ -1,0 +1,10 @@
+package com.first.flash.climbing.hold.application.dto;
+
+import com.first.flash.climbing.hold.domain.Hold;
+
+public record HoldResponseDto(Long id, String colorName, String colorCode) {
+
+    public static HoldResponseDto toDto(final Hold hold) {
+        return new HoldResponseDto(hold.getId(), hold.getColorName(), hold.getColorCode());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/hold/application/dto/HoldsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/hold/application/dto/HoldsResponseDto.java
@@ -1,0 +1,7 @@
+package com.first.flash.climbing.hold.application.dto;
+
+import java.util.List;
+
+public record HoldsResponseDto(List<HoldResponseDto> holdList) {
+
+}

--- a/src/main/java/com/first/flash/climbing/hold/domain/Hold.java
+++ b/src/main/java/com/first/flash/climbing/hold/domain/Hold.java
@@ -1,0 +1,31 @@
+package com.first.flash.climbing.hold.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Entity
+@NoArgsConstructor
+@Getter
+@ToString
+public class Hold {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String colorName;
+    private String colorCode;
+
+    protected Hold(final String colorName, final String colorCode) {
+        this.colorName = colorName;
+        this.colorCode = colorCode;
+    }
+
+    public static Hold of(final String colorName, final String colorCode) {
+        return new Hold(colorName, colorCode);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/hold/domain/HoldRepository.java
+++ b/src/main/java/com/first/flash/climbing/hold/domain/HoldRepository.java
@@ -1,0 +1,14 @@
+package com.first.flash.climbing.hold.domain;
+
+import com.first.flash.climbing.sector.domain.Sector;
+import java.util.List;
+import java.util.Optional;
+
+public interface HoldRepository {
+
+    Hold save(final Hold hold);
+
+    Optional<Hold> findById(final Long id);
+
+    List<Hold> findAll();
+}

--- a/src/main/java/com/first/flash/climbing/hold/exception/HoldExceptionHandler.java
+++ b/src/main/java/com/first/flash/climbing/hold/exception/HoldExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.first.flash.climbing.hold.exception;
+
+import com.first.flash.climbing.hold.exception.exceptions.HoldNotFoundException;
+import com.first.flash.global.dto.ErrorResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class HoldExceptionHandler {
+
+    @ExceptionHandler(HoldNotFoundException.class)
+    public ResponseEntity<ErrorResponseDto> handleHoldNotFoundException(
+        final HoldNotFoundException exception) {
+        return getResponseWithStatus(HttpStatus.NOT_FOUND, exception);
+    }
+
+    private ResponseEntity<ErrorResponseDto> getResponseWithStatus(final HttpStatus httpStatus,
+        final RuntimeException exception) {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(exception.getMessage());
+        return ResponseEntity.status(httpStatus)
+                             .body(errorResponse);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/hold/exception/exceptions/HoldNotFoundException.java
+++ b/src/main/java/com/first/flash/climbing/hold/exception/exceptions/HoldNotFoundException.java
@@ -1,0 +1,15 @@
+package com.first.flash.climbing.hold.exception.exceptions;
+
+import com.first.flash.climbing.sector.exception.exceptions.SectorNotFoundException;
+import com.first.flash.global.dto.ErrorResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+public class HoldNotFoundException extends RuntimeException {
+
+    public HoldNotFoundException(final Long id) {
+        super(String.format("아이디가 %s인 홀드를 찾을 수 없습니다.", id));
+    }
+}

--- a/src/main/java/com/first/flash/climbing/hold/infrastructure/HoldJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/hold/infrastructure/HoldJpaRepository.java
@@ -1,0 +1,15 @@
+package com.first.flash.climbing.hold.infrastructure;
+
+import com.first.flash.climbing.hold.domain.Hold;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface HoldJpaRepository extends JpaRepository<Hold, Long> {
+
+    Hold save(final Hold hold);
+
+    Optional<Hold> findById(final Long id);
+
+    List<Hold> findAll();
+}

--- a/src/main/java/com/first/flash/climbing/hold/infrastructure/HoldRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/hold/infrastructure/HoldRepositoryImpl.java
@@ -1,0 +1,30 @@
+package com.first.flash.climbing.hold.infrastructure;
+
+import com.first.flash.climbing.hold.domain.Hold;
+import com.first.flash.climbing.hold.domain.HoldRepository;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class HoldRepositoryImpl implements HoldRepository {
+
+    private final HoldJpaRepository holdJpaRepository;
+
+    @Override
+    public Hold save(Hold hold) {
+        return holdJpaRepository.save(hold);
+    }
+
+    @Override
+    public Optional<Hold> findById(Long id) {
+        return holdJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<Hold> findAll() {
+        return holdJpaRepository.findAll();
+    }
+}

--- a/src/main/java/com/first/flash/climbing/hold/ui/HoldController.java
+++ b/src/main/java/com/first/flash/climbing/hold/ui/HoldController.java
@@ -1,0 +1,52 @@
+package com.first.flash.climbing.hold.ui;
+
+import com.first.flash.climbing.hold.application.HoldService;
+import com.first.flash.climbing.hold.application.dto.HoldCreateRequestDto;
+import com.first.flash.climbing.hold.application.dto.HoldResponseDto;
+import com.first.flash.climbing.hold.application.dto.HoldsResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "holds", description = "홀드 정보 관리 API")
+@RestController
+@RequestMapping
+@RequiredArgsConstructor
+public class HoldController {
+
+    private final HoldService holdService;
+
+    @Operation(summary = "모든 홀드 정보 조회", description = "모든 홀드 정보를 리스트로 반환")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 홀드를 조회",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = HoldsResponseDto.class))),
+    })
+    @GetMapping("holds")
+    public ResponseEntity<HoldsResponseDto> findAllHolds() {
+        return ResponseEntity.ok(holdService.findAllHolds());
+    }
+
+    @Operation(summary = "홀드 정보 생성", description = "홀드 정보를 생성")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "홀드 정보를 생성",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = HoldResponseDto.class))),
+    })
+    @PostMapping("holds")
+    public ResponseEntity<HoldResponseDto> createHold(
+        @Valid @RequestBody final HoldCreateRequestDto createRequestDto) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                             .body(holdService.saveHold(createRequestDto));
+    }
+}


### PR DESCRIPTION
# 요약
<img width="300" alt="image" src="https://github.com/user-attachments/assets/79e746b2-e7b5-463e-98c2-2965c43a8d08">

홀드색 목록을 조회하기 위한 테이블과 관련 API 구현

# 내용

### 애그리거트 분리
<img width="249" alt="image" src="https://github.com/user-attachments/assets/690b1e81-4484-4327-8fe7-e8f8e9a31d8f">

- 생명주기를 같이 하는 기존 애그리거트가 없어 새로운 애그리거트로 분리하여 구현

### 테이블 구조

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5ba61fc6-83d7-4323-9b0a-438f478d5ed2">

- Hold 테이블
  - colorName: 색상 이름은 디버깅 용이성을 위해 추가
  - colorCode: 실제 사용되는 색상 코드.` # + 6자리 hex` 형태의 문자열

### 조회 API

- `GET /holds`
<img width="660" alt="image" src="https://github.com/user-attachments/assets/fe41756f-4723-417a-abec-05232e3fbec6">

### 생성 API

- `POST /holds`
<img width="660" alt="image" src="https://github.com/user-attachments/assets/42fa43b9-2a39-4eb1-8da2-419229dd3020">
