### PR TITLE
문제 등록 방식 변경, 해설 썸네일 정보 제공

### DIFF
--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/ClimbingGymQueryDslRepository.java
@@ -20,8 +20,8 @@ public class ClimbingGymQueryDslRepository {
 
     public List<SectorInfoResponseDto> findSortedSectorNamesByGymId(final Long gymId) {
         return jpaQueryFactory.select(
-                                  Projections.constructor(SectorInfoResponseDto.class, sector.sectorName.name,
-                                      sector.selectedImageUrl))
+                                  Projections.constructor(SectorInfoResponseDto.class, sector.id,
+                                      sector.sectorName.name, sector.selectedImageUrl))
                               .from(sector)
                               .where(sector.gymId.eq(gymId), sector.removalInfo.isExpired.isFalse())
                               .distinct()

--- a/src/main/java/com/first/flash/climbing/gym/infrastructure/dto/SectorInfoResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/gym/infrastructure/dto/SectorInfoResponseDto.java
@@ -1,5 +1,5 @@
 package com.first.flash.climbing.gym.infrastructure.dto;
 
-public record SectorInfoResponseDto(String name, String selectedImageUrl) {
+public record SectorInfoResponseDto(Long id, String name, String selectedImageUrl) {
 
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -36,6 +36,8 @@ public class ProblemEventHandler {
     @EventListener
     @Transactional
     public void updateProblemSolutionInfo(final SolutionSavedEvent event) {
+        problemsService.changeThumbnailInfo(event.getProblemId(), event.getSolutionId(),
+            event.getThumbnailImageUrl(), event.getUploader());
         problemsService.updateProblemSolutionInfo(event.getProblemId());
     }
 

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemEventHandler.java
@@ -8,6 +8,7 @@ import com.first.flash.climbing.sector.domain.SectorRemovalDateUpdatedEvent;
 import com.first.flash.climbing.solution.domain.PerceivedDifficultySetEvent;
 import com.first.flash.climbing.solution.domain.SolutionDeletedEvent;
 import com.first.flash.climbing.solution.domain.SolutionSavedEvent;
+import com.first.flash.climbing.solution.domain.SolutionUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -43,6 +44,13 @@ public class ProblemEventHandler {
 
     @EventListener
     @Transactional
+    public void updateThumbnailInfo(final SolutionUpdatedEvent event) {
+        problemsService.changeAllThumbnailInfo(event.getSolutionId(), event.getThumbnailImageUrl(),
+            event.getUploader());
+    }
+
+    @EventListener
+    @Transactional
     public void updateProblemDeletedSolutionInfo(final SolutionDeletedEvent event) {
         problemsService.updateProblemDeletedSolutionInfo(event.getProblemId(),
             event.getPerceivedDifficulty());
@@ -73,4 +81,6 @@ public class ProblemEventHandler {
         problemsService.addPerceivedDifficulty(event.getProblemId(),
             event.getPerceivedDifficulty());
     }
+
+
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemReadService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemReadService.java
@@ -4,7 +4,9 @@ import static com.first.flash.climbing.problem.infrastructure.paging.ProblemSort
 import static com.first.flash.climbing.problem.infrastructure.paging.ProblemSortBy.VIEWS;
 
 import com.first.flash.climbing.gym.domian.ClimbingGymIdConfirmRequestedEvent;
+import com.first.flash.climbing.problem.application.dto.DuplicateProblemsResponseDto;
 import com.first.flash.climbing.problem.application.dto.ProblemDetailResponseDto;
+import com.first.flash.climbing.problem.application.dto.ProblemResponseDto;
 import com.first.flash.climbing.problem.application.dto.ProblemsResponseDto;
 import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
@@ -64,6 +66,13 @@ public class ProblemReadService {
     public QueryProblem findQueryProblemById(final UUID problemId) {
         return queryProblemRepository.findById(problemId).orElseThrow(
             () -> new QueryProblemNotFoundException(problemId));
+    }
+
+    public DuplicateProblemsResponseDto findDuplicateProblems(final Long sectorId, final Long holdId,
+        final String difficulty) {
+        List<QueryProblem> duplicateProblems = queryProblemRepository.findBySectorIdAndHoldIdAndDifficulty(sectorId, holdId, difficulty);
+
+        return DuplicateProblemsResponseDto.of(duplicateProblems);
     }
 
     private void validateExpiration(final Problem problem, final QueryProblem queryProblem) {

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsSaveService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsSaveService.java
@@ -2,6 +2,8 @@ package com.first.flash.climbing.problem.application;
 
 import com.first.flash.climbing.gym.application.ClimbingGymService;
 import com.first.flash.climbing.gym.domian.ClimbingGym;
+import com.first.flash.climbing.hold.application.HoldService;
+import com.first.flash.climbing.hold.domain.Hold;
 import com.first.flash.climbing.problem.application.dto.ProblemCreateResponseDto;
 import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
@@ -24,6 +26,7 @@ public class ProblemsSaveService {
     private final QueryProblemRepository queryProblemRepository;
     private final ClimbingGymService climbingGymService;
     private final SectorService sectorService;
+    private final HoldService holdService;
     private final ProblemsCreateService problemsCreateService;
 
     @Transactional
@@ -31,10 +34,11 @@ public class ProblemsSaveService {
         final ProblemCreateRequestDto createRequestDto) {
         ClimbingGym climbingGym = climbingGymService.findClimbingGymById(gymId);
         Sector sector = sectorService.findById(sectorId);
+        Hold hold = holdService.findById(createRequestDto.holdId());
         Problem problem = problemsCreateService.createProblem(climbingGym, sector,
             createRequestDto);
         QueryProblem queryProblem = problemsCreateService.createQueryProblem(climbingGym,
-            sector, problem);
+            sector, problem, hold);
         problemRepository.save(problem);
         queryProblemRepository.save(queryProblem);
         return ProblemCreateResponseDto.toDto(problem);

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -5,6 +5,7 @@ import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
 import com.first.flash.climbing.problem.domain.QueryProblem;
 import com.first.flash.climbing.problem.domain.QueryProblemRepository;
+import com.first.flash.climbing.problem.infrastructure.dto.ThumbnailSolutionDto;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
@@ -55,8 +56,20 @@ public class ProblemsService {
     @Transactional
     public void updateProblemDeletedSolutionInfo(final UUID problemId,
         final Integer perceivedDifficulty) {
+        Problem problem = problemReadService.findProblemById(problemId);
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
+
         queryProblem.decrementSolutionCount();
+        if (!queryProblem.getHasSolution()) {
+            problemRepository.deleteByProblemId(problemId);
+            queryProblemRepository.deleteByProblemId(problemId);
+            return;
+        }
+
+        ThumbnailSolutionDto dto = problemRepository.findNextSolution(problemId);
+        problem.setThumbnailInfo(dto.solutionId(), dto.thumbnailImageUrl(), dto.uploader());
+        queryProblem.setThumbnailInfo(dto.solutionId(), dto.thumbnailImageUrl(), dto.uploader());
+
         queryProblem.subtractPerceivedDifficulty(perceivedDifficulty);
     }
 

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -38,6 +38,10 @@ public class ProblemsService {
         Problem problem = problemReadService.findProblemById(problemId);
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
 
+        if (queryProblem.getHasSolution()) {
+            return;
+        }
+
         problem.setThumbnailInfo(solutionId, thumbnailImageUrl, uploader);
         queryProblem.setThumbnailInfo(solutionId, thumbnailImageUrl, uploader);
     }

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -50,6 +50,16 @@ public class ProblemsService {
     }
 
     @Transactional
+    public void changeAllThumbnailInfo(final Long solutionId, final String thumbnailImageUrl, final String uploader) {
+        List<Problem> problems = problemRepository.findProblemsByThumbnailSolutionId(solutionId);
+        List<QueryProblem> queryProblems = queryProblemRepository.findProblemsByThumbnailSolutionId(
+            solutionId);
+
+        problems.forEach(problem -> problem.setThumbnailInfo(solutionId, thumbnailImageUrl, uploader));
+        queryProblems.forEach(queryProblem -> queryProblem.setThumbnailInfo(solutionId, thumbnailImageUrl, uploader));
+    }
+
+    @Transactional
     public void updateProblemSolutionInfo(final UUID problemId) {
         QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
         queryProblem.addSolutionCount();

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.problem.application;
 
 import com.first.flash.climbing.problem.application.dto.ProblemDetailResponseDto;
+import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
 import com.first.flash.climbing.problem.domain.QueryProblem;
 import com.first.flash.climbing.problem.domain.QueryProblemRepository;
@@ -29,6 +30,16 @@ public class ProblemsService {
     public void expireProblems(final List<Long> expiredSectorsIds) {
         queryProblemRepository.expireProblemsBySectorIds(expiredSectorsIds);
         problemRepository.expireProblemsBySectorIds(expiredSectorsIds);
+    }
+    
+    @Transactional
+    public void changeThumbnailInfo(final UUID problemId, final Long solutionId, 
+        final String thumbnailImageUrl, final String uploader) {
+        Problem problem = problemReadService.findProblemById(problemId);
+        QueryProblem queryProblem = problemReadService.findQueryProblemById(problemId);
+
+        problem.setThumbnailInfo(solutionId, thumbnailImageUrl, uploader);
+        queryProblem.setThumbnailInfo(solutionId, thumbnailImageUrl, uploader);
     }
 
     @Transactional

--- a/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/ProblemsService.java
@@ -1,6 +1,8 @@
 package com.first.flash.climbing.problem.application;
 
 import com.first.flash.climbing.problem.application.dto.ProblemDetailResponseDto;
+import com.first.flash.climbing.problem.application.dto.ProblemResponseDto;
+import com.first.flash.climbing.problem.application.dto.ProblemsResponseDto;
 import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
 import com.first.flash.climbing.problem.domain.QueryProblem;
@@ -96,4 +98,5 @@ public class ProblemsService {
     public void updateQueryProblemFixedInfo(final List<Long> sectorIds, final String sectorName) {
         queryProblemRepository.updateSectorNameBySectorIds(sectorIds, sectorName);
     }
+
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/DuplicateProblemsResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/DuplicateProblemsResponseDto.java
@@ -1,0 +1,14 @@
+package com.first.flash.climbing.problem.application.dto;
+
+import com.first.flash.climbing.problem.domain.QueryProblem;
+import com.first.flash.global.paging.Meta;
+import java.util.List;
+
+public record DuplicateProblemsResponseDto(List<ProblemResponseDto> problems) {
+
+    public static DuplicateProblemsResponseDto of(final List<QueryProblem> queryProblems) {
+        return new DuplicateProblemsResponseDto(queryProblems.stream()
+                                                    .map(ProblemResponseDto::toDto)
+                                                    .toList());
+    }
+}

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemCreateResponseDto.java
@@ -8,7 +8,8 @@ import lombok.Builder;
 @Builder
 public record ProblemCreateResponseDto(UUID id, String imageUrl, Integer views, Boolean isExpired,
                                        DifficultyInfo difficultyInfo, Long optionalWeight,
-                                       Long gymId, Long sectorId, String imageSource
+                                       Long gymId, Long sectorId, String imageSource,
+                                       Long thumbnailSolutionId, Long holdId
 ) {
 
     public static ProblemCreateResponseDto toDto(final Problem problem) {
@@ -22,6 +23,8 @@ public record ProblemCreateResponseDto(UUID id, String imageUrl, Integer views, 
                                        .gymId(problem.getGymId())
                                        .sectorId(problem.getSectorId())
                                        .imageSource(problem.getImageSource())
+                                       .thumbnailSolutionId(problem.getThumbnailSolutionId())
+                                       .holdId(problem.getHoldId())
                                        .build();
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemDetailResponseDto.java
@@ -7,13 +7,14 @@ import java.util.UUID;
 public record ProblemDetailResponseDto(UUID id, String sector, String difficulty,
                                        LocalDate settingDate, LocalDate removalDate,
                                        boolean isFakeRemovalDate, boolean hasSolution,
+                                       String holdColorCode,
                                        String imageUrl, String gymName, String imageSource, Boolean isHoney) {
 
     public static ProblemDetailResponseDto of(final QueryProblem queryProblem) {
         return new ProblemDetailResponseDto(queryProblem.getId(), queryProblem.getSectorName(),
             queryProblem.getDifficultyName(), queryProblem.getSettingDate(),
             queryProblem.getRemovalDate(), queryProblem.getIsFakeRemovalDate(),
-            queryProblem.getHasSolution(), queryProblem.getImageUrl(), queryProblem.getGymName(),
-            queryProblem.getImageSource(), queryProblem.isHoney());
+            queryProblem.getHasSolution(), queryProblem.getHoldColorCode(), queryProblem.getImageUrl(),
+            queryProblem.getGymName(), queryProblem.getImageSource(), queryProblem.isHoney());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/application/dto/ProblemResponseDto.java
@@ -6,12 +6,13 @@ import java.util.UUID;
 
 public record ProblemResponseDto(UUID id, String sector, String difficulty, LocalDate settingDate,
                                  LocalDate removalDate, boolean hasSolution, String imageUrl,
-                                 Boolean isHoney, Integer solutionCount) {
+                                 String holdColorCode, Boolean isHoney, Integer solutionCount) {
 
     public static ProblemResponseDto toDto(QueryProblem queryProblem) {
         return new ProblemResponseDto(queryProblem.getId(), queryProblem.getSectorName(),
             queryProblem.getDifficultyName(), queryProblem.getSettingDate(),
             queryProblem.getRemovalDate(), queryProblem.getHasSolution(),
-            queryProblem.getImageUrl(), queryProblem.isHoney(), queryProblem.getSolutionCount());
+            queryProblem.getImageUrl(), queryProblem.getHoldColorCode(),
+            queryProblem.isHoney(), queryProblem.getSolutionCount());
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
@@ -63,4 +63,11 @@ public class Problem {
     public boolean isExpired() {
         return isExpired;
     }
+
+    public void setThumbnailInfo(final Long thumbnailSolutionId, final String imageUrl,
+        final String imageSource) {
+        this.thumbnailSolutionId = thumbnailSolutionId;
+        this.imageUrl = imageUrl;
+        this.imageSource = imageSource;
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/Problem.java
@@ -35,10 +35,12 @@ public class Problem {
     private Long gymId;
     private Long sectorId;
     private String imageSource;
+    private Long thumbnailSolutionId;
+    private Long holdId;
 
     public static Problem createDefault(final UUID id, final String imageUrl,
         final String difficultyName, final Integer difficultyLevel, final Long gymId,
-        final Long sectorId, final String imageSource) {
+        final Long sectorId, final String imageSource, final Long thumbnailSolutionId, final Long holdId) {
         return Problem.builder()
                       .id(id)
                       .imageUrl(imageUrl)
@@ -49,6 +51,8 @@ public class Problem {
                       .gymId(gymId)
                       .sectorId(sectorId)
                       .imageSource(imageSource)
+                      .thumbnailSolutionId(thumbnailSolutionId)
+                      .holdId(holdId)
                       .build();
     }
 

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
@@ -17,4 +17,6 @@ public interface ProblemRepository {
     void deleteByProblemId(final UUID problemId);
 
     ThumbnailSolutionDto findNextSolution(final UUID problemId);
+
+    List<Problem> findProblemsByThumbnailSolutionId(final Long solutionId);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemRepository.java
@@ -1,5 +1,7 @@
 package com.first.flash.climbing.problem.domain;
 
+import com.first.flash.climbing.problem.infrastructure.dto.ThumbnailSolutionDto;
+import com.first.flash.climbing.solution.domain.Solution;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -11,4 +13,8 @@ public interface ProblemRepository {
     Optional<Problem> findById(final UUID id);
 
     void expireProblemsBySectorIds(final List<Long> expiredSectorsIds);
+
+    void deleteByProblemId(final UUID problemId);
+
+    ThumbnailSolutionDto findNextSolution(final UUID problemId);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/ProblemsCreateService.java
@@ -2,6 +2,7 @@ package com.first.flash.climbing.problem.domain;
 
 import com.first.flash.climbing.gym.domian.ClimbingGym;
 import com.first.flash.climbing.gym.domian.vo.Difficulty;
+import com.first.flash.climbing.hold.domain.Hold;
 import com.first.flash.climbing.problem.domain.dto.ProblemCreateRequestDto;
 import com.first.flash.climbing.problem.util.UUIDGenerator;
 import com.first.flash.climbing.sector.domain.Sector;
@@ -26,11 +27,12 @@ public class ProblemsCreateService {
         UUID generatedUUID = uuidGenerator.generate();
 
         return Problem.createDefault(generatedUUID, createRequestDto.imageUrl(),
-            difficulty.getName(), difficulty.getLevel(), climbingGym.getId(), sector.getId(), createRequestDto.imageSource());
+            difficulty.getName(), difficulty.getLevel(), climbingGym.getId(), sector.getId(),
+            createRequestDto.imageSource(), createRequestDto.thumbnailSolutionId(), createRequestDto.holdId());
     }
 
     public QueryProblem createQueryProblem(final ClimbingGym climbingGym, final Sector sector,
-        final Problem problem) {
+        final Problem problem, final Hold hold) {
         return QueryProblem.builder()
                            .id(problem.getId())
                            .imageUrl(problem.getImageUrl())
@@ -51,6 +53,10 @@ public class ProblemsCreateService {
                            .sectorName(sector.getSectorName().getName())
                            .settingDate(sector.getSettingDate())
                            .removalDate(sector.getRemovalDate())
+                           .thumbnailSolutionId(problem.getThumbnailSolutionId())
+                           .holdId(hold.getId())
+                           .holdColorName(hold.getColorName())
+                           .holdColorCode(hold.getColorCode())
                            .build();
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -98,6 +98,13 @@ public class QueryProblem {
         return perceivedDifficulty < 0;
     }
 
+    public void setThumbnailInfo(final Long thumbnailSolutionId, final String imageUrl,
+        final String imageSource) {
+        this.thumbnailSolutionId = thumbnailSolutionId;
+        this.imageUrl = imageUrl;
+        this.imageSource = imageSource;
+    }
+
     private void enableSolution() {
         if (!hasSolution) {
             hasSolution = true;
@@ -113,4 +120,5 @@ public class QueryProblem {
             (STANDARD_VIEW_COUNT + difficultyLevel * DIFFICULTY_LEVEL_WEIGHT) * solutionCount
                 + optionalWeight;
     }
+
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblem.java
@@ -58,6 +58,10 @@ public class QueryProblem {
     private String sectorName;
     private LocalDate settingDate;
     private LocalDate removalDate;
+    private Long thumbnailSolutionId;
+    private Long holdId;
+    private String holdColorName;
+    private String holdColorCode;
 
     public boolean isExpired() {
         return isExpired;

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -29,4 +29,6 @@ public interface QueryProblemRepository {
     void deleteByProblemId(final UUID problemId);
 
     List<QueryProblem> findBySectorIdAndHoldIdAndDifficulty(Long sectorId, Long holdId, String difficulty);
+
+    List<QueryProblem> findProblemsByThumbnailSolutionId(Long solutionId);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -25,4 +25,5 @@ public interface QueryProblemRepository {
         final LocalDate settingDate, final boolean isExpired);
 
     void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName);
+
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -26,4 +26,5 @@ public interface QueryProblemRepository {
 
     void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName);
 
+    void deleteByProblemId(final UUID problemId);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/QueryProblemRepository.java
@@ -27,4 +27,6 @@ public interface QueryProblemRepository {
     void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName);
 
     void deleteByProblemId(final UUID problemId);
+
+    List<QueryProblem> findBySectorIdAndHoldIdAndDifficulty(Long sectorId, Long holdId, String difficulty);
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
@@ -1,10 +1,13 @@
 package com.first.flash.climbing.problem.domain.dto;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 
 public record ProblemCreateRequestDto(
     @NotEmpty(message = "이미지 URL은 필수입니다.") String imageUrl,
     @NotEmpty(message = "난이도는 필수입니다.") String difficulty,
-    @NotEmpty(message = "이미지 출처는 필수입니다.") String imageSource) {
+    @NotEmpty(message = "이미지 출처는 필수입니다.") String imageSource,
+    @NotNull(message = "썸네일 해설 아이디는 필수입니다.") Long thumbnailSolutionId,
+    @NotNull(message = "홀드 아이디는 필수입니다.") Long holdId) {
 
 }

--- a/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/domain/dto/ProblemCreateRequestDto.java
@@ -4,10 +4,10 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 
 public record ProblemCreateRequestDto(
-    @NotEmpty(message = "이미지 URL은 필수입니다.") String imageUrl,
+    String imageUrl,
+    String imageSource,
+    Long thumbnailSolutionId,
     @NotEmpty(message = "난이도는 필수입니다.") String difficulty,
-    @NotEmpty(message = "이미지 출처는 필수입니다.") String imageSource,
-    @NotNull(message = "썸네일 해설 아이디는 필수입니다.") Long thumbnailSolutionId,
     @NotNull(message = "홀드 아이디는 필수입니다.") Long holdId) {
 
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemJpaRepository.java
@@ -10,4 +10,6 @@ public interface ProblemJpaRepository extends JpaRepository<Problem, UUID> {
     Problem save(final Problem problem);
 
     Optional<Problem> findById(final UUID id);
+
+    void deleteById(final UUID id);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemJpaRepository.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.problem.infrastructure;
 
 import com.first.flash.climbing.problem.domain.Problem;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ public interface ProblemJpaRepository extends JpaRepository<Problem, UUID> {
     Optional<Problem> findById(final UUID id);
 
     void deleteById(final UUID id);
+
+    List<Problem> findProblemsByThumbnailSolutionId(final Long solutionId);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemQueryDslRepository.java
@@ -2,8 +2,12 @@ package com.first.flash.climbing.problem.infrastructure;
 
 import static com.first.flash.climbing.problem.domain.QProblem.problem;
 
+import com.first.flash.climbing.problem.infrastructure.dto.ThumbnailSolutionDto;
+import com.first.flash.climbing.solution.domain.QSolution;
+import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -18,5 +22,19 @@ public class ProblemQueryDslRepository {
                     .set(problem.isExpired, true)
                     .where(problem.sectorId.in(expiredSectorsIds))
                     .execute();
+    }
+
+    public ThumbnailSolutionDto findNextSolution(UUID problemId) {
+        QSolution solution = QSolution.solution;
+
+        return queryFactory.select(Projections.constructor(ThumbnailSolutionDto.class,
+                               solution.id,
+                               solution.uploaderDetail.uploader,
+                               solution.solutionDetail.thumbnailImageUrl))
+                           .from(solution)
+                           .where(solution.problemId.eq(problemId))
+                           .orderBy(solution.createdAt.asc())
+                           .limit(1)
+                           .fetchOne();
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.first.flash.climbing.problem.infrastructure;
 
 import com.first.flash.climbing.problem.domain.Problem;
 import com.first.flash.climbing.problem.domain.ProblemRepository;
+import com.first.flash.climbing.problem.infrastructure.dto.ThumbnailSolutionDto;
+import com.first.flash.climbing.solution.domain.Solution;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -28,5 +30,15 @@ public class ProblemRepositoryImpl implements ProblemRepository {
     @Override
     public void expireProblemsBySectorIds(final List<Long> expiredSectorsIds) {
         queryDslRepository.expireProblemsBySectorIds(expiredSectorsIds);
+    }
+
+    @Override
+    public void deleteByProblemId(UUID problemId) {
+        jpaRepository.deleteById(problemId);
+    }
+
+    @Override
+    public ThumbnailSolutionDto findNextSolution(UUID problemId) {
+        return queryDslRepository.findNextSolution(problemId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/ProblemRepositoryImpl.java
@@ -33,12 +33,17 @@ public class ProblemRepositoryImpl implements ProblemRepository {
     }
 
     @Override
-    public void deleteByProblemId(UUID problemId) {
+    public void deleteByProblemId(final UUID problemId) {
         jpaRepository.deleteById(problemId);
     }
 
     @Override
-    public ThumbnailSolutionDto findNextSolution(UUID problemId) {
+    public ThumbnailSolutionDto findNextSolution(final UUID problemId) {
         return queryDslRepository.findNextSolution(problemId);
+    }
+
+    @Override
+    public List<Problem> findProblemsByThumbnailSolutionId(final Long solutionId) {
+        return jpaRepository.findProblemsByThumbnailSolutionId(solutionId);
     }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
@@ -10,4 +10,6 @@ public interface QueryProblemJpaRepository extends JpaRepository<QueryProblem, U
     QueryProblem save(final QueryProblem queryProblem);
 
     Optional<QueryProblem> findById(final UUID id);
+
+    void deleteById(final UUID id);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
@@ -14,5 +14,7 @@ public interface QueryProblemJpaRepository extends JpaRepository<QueryProblem, U
 
     void deleteById(final UUID id);
 
-    List<QueryProblem> findBySectorIdAndHoldIdAndDifficultyName(Long sectorId, Long holdId, String difficulty);
+    List<QueryProblem> findBySectorIdAndHoldIdAndDifficultyName(final Long sectorId, final Long holdId, final String difficulty);
+
+    List<QueryProblem> findProblemsByThumbnailSolutionId(final Long solutionId);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemJpaRepository.java
@@ -1,6 +1,7 @@
 package com.first.flash.climbing.problem.infrastructure;
 
 import com.first.flash.climbing.problem.domain.QueryProblem;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ public interface QueryProblemJpaRepository extends JpaRepository<QueryProblem, U
     Optional<QueryProblem> findById(final UUID id);
 
     void deleteById(final UUID id);
+
+    List<QueryProblem> findBySectorIdAndHoldIdAndDifficultyName(Long sectorId, Long holdId, String difficulty);
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -69,4 +69,9 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
         String difficulty) {
         return jpaRepository.findBySectorIdAndHoldIdAndDifficultyName(sectorId, holdId, difficulty);
     }
+
+    @Override
+    public List<QueryProblem> findProblemsByThumbnailSolutionId(Long solutionId) {
+        return jpaRepository.findProblemsByThumbnailSolutionId(solutionId);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -58,4 +58,9 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
     public void updateSectorNameBySectorIds(final List<Long> sectorIds, final String sectorName) {
         queryProblemQueryDslRepository.updateSectorNameBySectorIds(sectorIds, sectorName);
     }
+
+    @Override
+    public void deleteByProblemId(UUID problemId) {
+        jpaRepository.deleteById(problemId);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/QueryProblemRepositoryImpl.java
@@ -63,4 +63,10 @@ public class QueryProblemRepositoryImpl implements QueryProblemRepository {
     public void deleteByProblemId(UUID problemId) {
         jpaRepository.deleteById(problemId);
     }
+
+    @Override
+    public List<QueryProblem> findBySectorIdAndHoldIdAndDifficulty(Long sectorId, Long holdId,
+        String difficulty) {
+        return jpaRepository.findBySectorIdAndHoldIdAndDifficultyName(sectorId, holdId, difficulty);
+    }
 }

--- a/src/main/java/com/first/flash/climbing/problem/infrastructure/dto/ThumbnailSolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/problem/infrastructure/dto/ThumbnailSolutionDto.java
@@ -1,0 +1,7 @@
+package com.first.flash.climbing.problem.infrastructure.dto;
+
+import java.util.UUID;
+
+public record ThumbnailSolutionDto(Long solutionId, String uploader, String thumbnailImageUrl) {
+
+}

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -56,7 +56,7 @@ public class ProblemController {
                 @ExampleObject(name = "난이도 없음", value = "{\"error\": \"이름이 핑크인 난이도를 찾을 수 없습니다.\"}")
             }))
     })
-    @PostMapping("/admin/gyms/{gymId}/sectors/{sectorId}/problems")
+    @PostMapping("/gyms/{gymId}/sectors/{sectorId}/problems")
     public ResponseEntity<ProblemCreateResponseDto> saveProblems(
         @PathVariable("gymId") final Long gymId,
         @PathVariable("sectorId") final Long sectorId,

--- a/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
+++ b/src/main/java/com/first/flash/climbing/problem/ui/ProblemController.java
@@ -3,6 +3,7 @@ package com.first.flash.climbing.problem.ui;
 import com.first.flash.climbing.problem.application.ProblemReadService;
 import com.first.flash.climbing.problem.application.ProblemsSaveService;
 import com.first.flash.climbing.problem.application.ProblemsService;
+import com.first.flash.climbing.problem.application.dto.DuplicateProblemsResponseDto;
 import com.first.flash.climbing.problem.application.dto.ProblemCreateResponseDto;
 import com.first.flash.climbing.problem.application.dto.ProblemDetailResponseDto;
 import com.first.flash.climbing.problem.application.dto.ProblemPerceivedDifficultyRequestDto;
@@ -122,5 +123,21 @@ public class ProblemController {
         @PathVariable final UUID problemId,
         @Valid @RequestBody final ProblemPerceivedDifficultyRequestDto requestDto) {
         return ResponseEntity.ok(problemsService.setPerceivedDifficulty(problemId, requestDto.perceivedDifficulty()));
+    }
+
+    @Operation(summary = "중복된 문제 조회", description = "sectorId, holdColorId, difficulty로 중복된 문제를 조회")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "성공적으로 중복된 문제 조회",
+            content = @Content(mediaType = "application/json", schema = @Schema(implementation = DuplicateProblemsResponseDto.class)))
+    })
+    @GetMapping("/problems/duplicate")
+    public ResponseEntity<DuplicateProblemsResponseDto> findDuplicateProblems(
+        @RequestParam("sectorId") final Long sectorId,
+        @RequestParam("holdColorId") final Long holdId,
+        @RequestParam("difficulty") final String difficulty) {
+
+        DuplicateProblemsResponseDto response = problemReadService.findDuplicateProblems(sectorId, holdId, difficulty);
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -42,7 +42,10 @@ public class SolutionSaveService {
             perceivedDifficulty.getValue()));
 
         Solution savedSolution = solutionRepository.save(solution);
-        Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
+        Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId(), savedSolution.getId(),
+            savedSolution.getSolutionDetail().getThumbnailImageUrl(),
+            savedSolution.getUploaderDetail().getInstagramId()));
+
         return SolutionWriteResponseDto.toDto(savedSolution);
     }
 
@@ -70,7 +73,9 @@ public class SolutionSaveService {
         Solution savedSolution = solutionRepository.save(solution);
         Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(),
             perceivedDifficulty.getValue()));
-        Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId()));
+        Events.raise(SolutionSavedEvent.of(savedSolution.getProblemId(), savedSolution.getId(),
+            savedSolution.getSolutionDetail().getThumbnailImageUrl(),
+            savedSolution.getUploaderDetail().getInstagramId()));
         return SolutionWriteResponseDto.toDto(savedSolution);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionSaveService.java
@@ -34,7 +34,8 @@ public class SolutionSaveService {
 
         PerceivedDifficulty perceivedDifficulty = createRequestDto.perceivedDifficulty();
         Solution solution = Solution.of(member.getNickName(), createRequestDto.review(),
-            member.getInstagramId(), createRequestDto.videoUrl(), problemId, member.getId(),
+            member.getInstagramId(), createRequestDto.thumbnailImageUrl(), createRequestDto.solvedDate(),
+            createRequestDto.videoUrl(), problemId, member.getId(),
             member.getProfileImageUrl(), perceivedDifficulty, member.getHeight(), member.getReach(),
             member.getGender());
         Events.raise(PerceivedDifficultySetEvent.of(solution.getProblemId(),
@@ -61,7 +62,8 @@ public class SolutionSaveService {
 
         PerceivedDifficulty perceivedDifficulty = requestDto.perceivedDifficulty();
         Solution solution = Solution.of(requestDto.nickName(), requestDto.review(),
-            requestDto.instagramId(), requestDto.videoUrl(), problemId, member.getId(),
+            requestDto.instagramId(), requestDto.thumbnailImageUrl(), requestDto.solvedDate(),
+            requestDto.videoUrl(), problemId, member.getId(),
             requestDto.profileImageUrl(), perceivedDifficulty, member.getHeight(),
             member.getReach(), member.getGender());
 

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -12,6 +12,7 @@ import com.first.flash.climbing.solution.domain.PerceivedDifficultySetEvent;
 import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.SolutionDeletedEvent;
 import com.first.flash.climbing.solution.domain.SolutionRepository;
+import com.first.flash.climbing.solution.domain.SolutionUpdatedEvent;
 import com.first.flash.climbing.solution.domain.dto.SolutionResponseDto;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionAccessDeniedException;
 import com.first.flash.climbing.solution.exception.exceptions.SolutionNotFoundException;
@@ -79,9 +80,11 @@ public class SolutionService {
         PerceivedDifficulty oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
         int difficultyDifference = newPerceivedDifficulty.calculateDifferenceFrom(oldPerceivedDifficulty);
 
-        solution.updateContentInfo(requestDto.review(), requestDto.thumbnailImageUrl(),
-            requestDto.videoUrl(), requestDto.solvedDate(), newPerceivedDifficulty);
+        solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(),
+            requestDto.thumbnailImageUrl(), requestDto.solvedDate(), newPerceivedDifficulty);
 
+        Events.raise(SolutionUpdatedEvent.of(solution.getId(), requestDto.thumbnailImageUrl(),
+            solution.getUploaderDetail().getUploader()));
         Events.raise(PerceivedDifficultySetEvent.of(
             solution.getProblemId(),
             difficultyDifference

--- a/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/SolutionService.java
@@ -79,7 +79,8 @@ public class SolutionService {
         PerceivedDifficulty oldPerceivedDifficulty = solution.getSolutionDetail().getPerceivedDifficulty();
         int difficultyDifference = newPerceivedDifficulty.calculateDifferenceFrom(oldPerceivedDifficulty);
 
-        solution.updateContentInfo(requestDto.review(), requestDto.videoUrl(), newPerceivedDifficulty);
+        solution.updateContentInfo(requestDto.review(), requestDto.thumbnailImageUrl(),
+            requestDto.videoUrl(), requestDto.solvedDate(), newPerceivedDifficulty);
 
         Events.raise(PerceivedDifficultySetEvent.of(
             solution.getProblemId(),

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionUpdateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionUpdateRequestDto.java
@@ -5,10 +5,13 @@ import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 
 public record SolutionUpdateRequestDto(
+    @NotEmpty(message = "썸네일 URL은 필수입니다.") String thumbnailImageUrl,
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
     @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review,
+    @NotNull(message = "풀이 일자 정보는 필수입니다.") LocalDate solvedDate,
     @NotNull(message = "체감 난이도는 필수입니다.")
     @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionWriteResponseDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/SolutionWriteResponseDto.java
@@ -4,10 +4,12 @@ import com.first.flash.climbing.solution.domain.Solution;
 import com.first.flash.climbing.solution.domain.vo.SolutionDetail;
 import com.first.flash.climbing.solution.domain.vo.UploaderDetail;
 import com.first.flash.global.util.AuthUtil;
+import java.time.LocalDate;
 import java.util.UUID;
 
 public record SolutionWriteResponseDto(Long id, String uploader, String review, String instagramId,
-                                       String videoUrl, UUID uploaderId, Boolean isUploader,
+                                       String thumbnailImageUrl, String videoUrl, LocalDate solvedDate,
+                                       UUID uploaderId, Boolean isUploader,
                                        String profileImageUrl) {
 
     public static SolutionWriteResponseDto toDto(final Solution solution) {
@@ -18,7 +20,8 @@ public record SolutionWriteResponseDto(Long id, String uploader, String review, 
 
         return new SolutionWriteResponseDto(solution.getId(), uploaderDetail.getUploader(),
             solutionDetail.getReview(), uploaderDetail.getInstagramId(),
-            solutionDetail.getVideoUrl(), uploaderDetail.getUploaderId(), isUploader,
+            solutionDetail.getThumbnailImageUrl(), solutionDetail.getVideoUrl(),
+            solutionDetail.getSolvedDate(), uploaderDetail.getUploaderId(), isUploader,
             uploaderDetail.getProfileImageUrl());
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
+++ b/src/main/java/com/first/flash/climbing/solution/application/dto/UnregisteredMemberSolutionCreateRequest.java
@@ -4,12 +4,15 @@ import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 public record UnregisteredMemberSolutionCreateRequest(
     @NotEmpty(message = "닉네임은 필수입니다.") String nickName,
     @NotEmpty(message = "인스타그램 아이디는 필수입니다.") String instagramId,
     String review, String profileImageUrl,
+    @NotEmpty(message = "썸네일 URL은 필수입니다.") String thumbnailImageUrl,
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
+    @NotNull(message = "풀이 일자 정보는 필수입니다.") LocalDate solvedDate,
     @NotNull(message = "체감 난이도는 필수입니다.")
     @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 

--- a/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/Solution.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -41,12 +42,14 @@ public class Solution extends BaseEntity {
     private List<SolutionComment> comments = new ArrayList<>();
 
     protected Solution(final String uploader, final String review, final String instagramId,
+        final String thumbnailImageUrl, final LocalDate solvedDate,
         final String videoUrl, final UUID problemId, final UUID uploaderId,
         final String profileImageUrl, final PerceivedDifficulty perceivedDifficulty,
         final Double uploaderHeight,
         final Double uploaderReach, final Gender uploaderGender) {
 
-        this.solutionDetail = SolutionDetail.of(review, videoUrl, perceivedDifficulty);
+        this.solutionDetail = SolutionDetail.of(review, thumbnailImageUrl, videoUrl,
+            solvedDate, perceivedDifficulty);
         this.uploaderDetail = UploaderDetail.of(uploaderId, uploader, instagramId, profileImageUrl,
             uploaderHeight, uploaderReach, uploaderGender);
         this.optionalWeight = DEFAULT_OPTIONAL_WEIGHT;
@@ -54,16 +57,20 @@ public class Solution extends BaseEntity {
     }
 
     public static Solution of(final String uploader, final String review, final String instagramId,
+        final String thumbnailImageUrl, final LocalDate solvedDate,
         final String videoUrl, final UUID problemId, final UUID uploaderId,
         final String profileImageUrl, final PerceivedDifficulty perceivedDifficulty,
-        final Double uploaderHeight, final Double uploaderReach, final Gender uploaderGender) {
+        final Double uploaderHeight,
+        final Double uploaderReach, final Gender uploaderGender) {
 
-        return new Solution(uploader, review, instagramId, videoUrl, problemId, uploaderId,
+        return new Solution(uploader, review, instagramId, thumbnailImageUrl, solvedDate, videoUrl,
+            problemId, uploaderId,
             profileImageUrl, perceivedDifficulty, uploaderHeight, uploaderReach, uploaderGender);
     }
 
-    public void updateContentInfo(final String review, final String videoUrl,
-        final PerceivedDifficulty perceivedDifficulty) {
-        this.solutionDetail = SolutionDetail.of(review, videoUrl, perceivedDifficulty);
+    public void updateContentInfo(final String review, final String videoUrl, final String thumbnailImageUrl,
+        final LocalDate solvedDate, final PerceivedDifficulty perceivedDifficulty) {
+        this.solutionDetail = SolutionDetail.of(review, thumbnailImageUrl, videoUrl,
+            solvedDate, perceivedDifficulty);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionSavedEvent.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionSavedEvent.java
@@ -10,8 +10,12 @@ import lombok.Getter;
 public class SolutionSavedEvent extends Event {
 
     private UUID problemId;
+    private Long solutionId;
+    private String thumbnailImageUrl;
+    private String uploader;
 
-    public static SolutionSavedEvent of(final UUID problemId) {
-        return new SolutionSavedEvent(problemId);
+    public static SolutionSavedEvent of(final UUID problemId, Long solutionId,
+        String thumbnailImageUrl, String uploader) {
+        return new SolutionSavedEvent(problemId, solutionId, thumbnailImageUrl, uploader);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/SolutionUpdatedEvent.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/SolutionUpdatedEvent.java
@@ -1,0 +1,20 @@
+package com.first.flash.climbing.solution.domain;
+
+import com.first.flash.global.event.Event;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SolutionUpdatedEvent extends Event {
+
+    private Long solutionId;
+    private String thumbnailImageUrl;
+    private String uploader;
+
+    public static SolutionUpdatedEvent of(final Long solutionId, final String thumbnailImageUrl,
+        final String uploader) {
+        return new SolutionUpdatedEvent(solutionId, thumbnailImageUrl, uploader);
+    }
+}

--- a/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/dto/SolutionCreateRequestDto.java
@@ -3,16 +3,23 @@ package com.first.flash.climbing.solution.domain.dto;
 import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.global.annotation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
 
 public record SolutionCreateRequestDto(
+    @NotEmpty(message = "썸네일 URL은 필수입니다.") String thumbnailImageUrl,
     @NotEmpty(message = "비디오 URL은 필수입니다.") String videoUrl,
     @Size(max = 500, message = "리뷰는 최대 500자까지 가능합니다.") String review,
+    @NotNull(message = "풀이 일자 정보는 필수입니다.") LocalDate solvedDate,
     @ValidEnum(enumClass = PerceivedDifficulty.class) PerceivedDifficulty perceivedDifficulty) {
 
-    public SolutionCreateRequestDto(final String videoUrl, final String review, final PerceivedDifficulty perceivedDifficulty) {
+    public SolutionCreateRequestDto(final String thumbnailImageUrl, final String videoUrl,
+        final String review, final LocalDate solvedDate, final PerceivedDifficulty perceivedDifficulty) {
+        this.thumbnailImageUrl = thumbnailImageUrl;
         this.videoUrl = videoUrl;
         this.review = review;
+        this.solvedDate = solvedDate;
         this.perceivedDifficulty = perceivedDifficulty != null ? perceivedDifficulty : PerceivedDifficulty.NORMAL;
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
+++ b/src/main/java/com/first/flash/climbing/solution/domain/vo/SolutionDetail.java
@@ -4,6 +4,7 @@ import com.first.flash.climbing.solution.domain.PerceivedDifficulty;
 import com.first.flash.climbing.solution.domain.PerceivedDifficultyConverter;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,17 +18,23 @@ import lombok.ToString;
 public class SolutionDetail {
 
     private String review;
+    private String thumbnailImageUrl;
     private String videoUrl;
+    private LocalDate solvedDate;
     @Convert(converter = PerceivedDifficultyConverter.class)
     private PerceivedDifficulty perceivedDifficulty;
 
-    protected SolutionDetail(final String review, final String videoUrl, final PerceivedDifficulty perceivedDifficulty) {
+    protected SolutionDetail(final String review, final String thumbnailImageUrl, final String videoUrl,
+        final LocalDate solvedDate, final PerceivedDifficulty perceivedDifficulty) {
         this.review = review;
+        this.thumbnailImageUrl = thumbnailImageUrl;
         this.videoUrl = videoUrl;
+        this.solvedDate = solvedDate;
         this.perceivedDifficulty = perceivedDifficulty;
     }
 
-    public static SolutionDetail of(final String review, final String videoUrl, final PerceivedDifficulty perceivedDifficulty) {
-        return new SolutionDetail(review, videoUrl, perceivedDifficulty);
+    public static SolutionDetail of(final String review, final String thumbnailImageUrl, final String videoUrl,
+        final LocalDate solvedDate, final PerceivedDifficulty perceivedDifficulty) {
+        return new SolutionDetail(review, thumbnailImageUrl, videoUrl, solvedDate, perceivedDifficulty);
     }
 }

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -48,8 +48,8 @@ public class SolutionQueryDslRepository {
         final List<String> difficulty) {
         return jpaQueryFactory.select(Projections.constructor(MySolutionDto.class,
                                   solution.id, queryProblem.gymName, queryProblem.sectorName,
-                                  queryProblem.difficultyName, queryProblem.imageUrl, solutionComment.count(),
-                                  solution.createdAt
+                                  queryProblem.difficultyName, solution.solutionDetail.thumbnailImageUrl,
+                                  solutionComment.count(), solution.solutionDetail.solvedDate, solution.updatedAt
                               ))
                               .from(solution)
                               .innerJoin(queryProblem)

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/MySolutionDto.java
@@ -1,9 +1,10 @@
 package com.first.flash.climbing.solution.infrastructure.dto;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 public record MySolutionDto(Long solutionId, String gymName, String sectorName,
-                            String difficultyName, String problemImageUrl, Long commentsCount,
-                            LocalDateTime uploadedAt) {
+                            String difficultyName, String thumbnailImageUrl, Long commentsCount,
+                            LocalDate solvedDate, LocalDateTime uploadedAt) {
 
 }


### PR DESCRIPTION
# 요약

첫 해설 등록 시 문제를 함께 생성하기 위해 로직 변경

# 내용

## 클라이밍장 상세 정보 조회 시 sectorId 정보 제공

- `GET /gyms/{gymId}`
- 해설로 문제 생성을 하기 위해 sector id 정보가 필요하여 추가

## Solution에 풀이 일자, 썸네일 url 추가

- 풀이 일자: solvedDate, 썸네일 url: thumbnailImageUrl 컬럼 추가

## problem에 홀드 정보, 썸네일 해설 정보 추가

- 홀드 정보: holdId, 썸네일 해설 정보: thumbnailSolutionId
- queryproblem에는 홀드 색, 홀드 색상 코드 정보도 포함
- 문제 다건, 단건 조회 시 홀드 색상 코드를 제공

## 문제 생성을 일반 유저도 할 수 있도록 변경

- 기존 Endpoint: `POST /admin/gyms/{gymId}/sectors/{sectorId}/problems`
- 새로운 Endpoint: `POST /gyms/{gymId}/sectors/{sectorId}/problems`

### 새로운 해설 업로드 시 작업 순서

1. 업로드 서버에 새로운 해설 업로드
2. 트랜스코딩 이후 Lambda에서 문제 생성 API 호출 (이 때는 thumbnailSolutionId, thumbnailImageUrl이 설정되어 있지 않음)
3. 문제 생성이 완료되면 같은 Lambda에서 해설 생성 API 호출 (이 때 해설 생성 이벤트가 발성하여 문제의 썸네일 및 썸네일 id 정보가 설정)

## 기존에 있는 문제 업로드 API 변경

- 기존에 있는 문제에 해설 업로드
   - 풀이 날짜, 썸네일 이미지 파라미터 추가

## 없는 유저의 해설 업로드

- 어드민 기능인 없는 유저의 해설 업로드 API도 두 개로 분리됨
  - 기존 문제에 해설 업로드
  - 새로운 문제를 생성하며 해설 업로드

### 기존 문제에 해설 업로드

- 풀이 날짜, 썸네일 이미지 파라미터 추가

### 새로운 문제를 생성하며 해설 업로드

- 기존 백엔드 로직은 변경 없음
- 업로드 서버 및 Lambda 파라미터 변경 예정

## 업로드된 해설 영상 수정

- 풀이 날짜를 수정할 수 있는 파라미터 추가
- 썸네일 수정은 불가능

## 해설 삭제 로직 변경

- 해설 삭제 시 다음 해설이 문제의 썸네일로 설정
- 남은 해설이 없는 경우 문제가 삭제

## 마이페이지의 해설 조회 시 제공 정보 변경

- 썸네일 url, 풀이 날짜 정보를 추가로 제공

## 같은 섹터, 난이도, 홀드색을 가진 문제가 있는지 조회하는 API 구현

<img width="200" alt="image" src="https://github.com/user-attachments/assets/5f4c0b75-6b07-42e2-b096-4915a760ddc8">

- 위 기능을 위해 구현

<img width="693" alt="image" src="https://github.com/user-attachments/assets/52d8e468-3304-410d-b4e8-a187b3553f33">

- 쿼리를 이용해 요청
- 빈 리스트가 반환될 경우 중복된 문제가 없다는 뜻