### PR TITLE
feat: 해설 상세 조회 API에 정보 추가

### DIFF
--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/SolutionQueryDslRepository.java
@@ -85,6 +85,7 @@ public class SolutionQueryDslRepository {
                                   queryProblem.sectorName, solution.solutionDetail.review,
                                   queryProblem.difficultyName, solutionComment.count(),
                                   solution.solutionDetail.perceivedDifficulty,
+                                  solution.solutionDetail.thumbnailImageUrl, queryProblem.holdColorCode,
                                   queryProblem.removalDate, queryProblem.settingDate, solution.createdAt
                               ))
                               .from(solution)

--- a/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
+++ b/src/main/java/com/first/flash/climbing/solution/infrastructure/dto/DetailSolutionDto.java
@@ -6,5 +6,6 @@ import java.time.LocalDateTime;
 
 public record DetailSolutionDto(Long solutionId, String videoUrl, String gymName, String sectorName,
                                 String review, String difficultyName, Long commentsCount, PerceivedDifficulty perceivedDifficulty,
+                                String thumbnailImageUrl, String holdColorCode,
                                 LocalDate removalDate, LocalDate settingDate, LocalDateTime uploadedAt) {
 }


### PR DESCRIPTION
# 해설 상세 조회 API 

- GET /solutions/{solutionId} 
- 추가된 정보
  - 홀드 색상 정보: holdColorCode
  - 썸네일 이미지 URL: thumbnailImageUrl
